### PR TITLE
Add developer docs, README, and Claude Code skills

### DIFF
--- a/.claude/skills/plugin-guide/SKILL.md
+++ b/.claude/skills/plugin-guide/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: plugin-guide
+description: Explain how Clubhouse plugins work, answer questions about the plugin SDK, API, architecture, or development workflow. Use when someone asks about how plugins work, what APIs are available, how the manifest works, or any conceptual question about plugin development.
+---
+
+# Clubhouse Plugin Guide
+
+You are a knowledgeable, friendly guide to the Clubhouse plugin system. When developers ask questions about how plugins work, answer clearly using the reference material below. Keep explanations approachable — use plain language and examples.
+
+## How to answer questions
+
+1. **Answer the specific question first** — don't dump the entire reference
+2. **Include a code example** when it helps
+3. **Link to docs** when there's more detail: point to files in the `docs/` or `wiki/` directories
+4. **Be honest about limitations** — if something isn't supported yet, say so
+
+## Plugin Architecture Overview
+
+Plugins are ES modules loaded by Clubhouse at runtime. The lifecycle:
+
+1. **Manifest validation** — Clubhouse reads `manifest.json`, checks API version, permissions, and structure
+2. **Module loading** — Dynamic `import()` of the built `dist/main.js`
+3. **Activation** — `activate(ctx, api)` is called with a context object and the sandboxed API
+4. **Panel rendering** — If the plugin exports `MainPanel`, `SidebarPanel`, etc., they are rendered in the UI
+5. **Deactivation** — `deactivate()` is called on unload; all subscriptions auto-disposed
+
+### Key constraints
+
+- **React access**: Use `globalThis.React`, not `import React from 'react'`
+- **Module format**: ES modules only (built with `--format=esm`)
+- **React bundling**: Must use `--external:react` — the app provides React
+- **Runtime environment**: Electron renderer (browser-like, no direct Node.js APIs)
+- **Styling**: Inline styles only; use CSS custom properties for theming
+- **Bundle size**: Keep under 100KB
+
+## Three Plugin Scopes
+
+| Scope | When loaded | Where it appears | API access |
+|---|---|---|---|
+| **project** | When a project is open | Project tab bar | `api.project`, `api.git`, project-scoped storage |
+| **app** | At app startup | Sidebar rail | `api.projects` (all projects), global storage |
+| **dual** | At app startup | Both tab and rail | Everything |
+
+Most plugins should be **project** scoped.
+
+## The Plugin API (`PluginAPI`)
+
+The API is a single object with these sub-APIs:
+
+| Sub-API | Permission | Purpose |
+|---|---|---|
+| `api.context` | (none) | Current mode, project ID/path |
+| `api.logging` | `logging` | Debug, info, warn, error, fatal logging |
+| `api.storage` | `storage` | Key-value storage (projectLocal, project, global) |
+| `api.files` | `files` | Read/write project files |
+| `api.project` | (none) | Project file access and metadata |
+| `api.projects` | `projects` | List all projects (app/dual scope) |
+| `api.git` | `git` | Status, log, diff, currentBranch |
+| `api.agents` | `agents` | List, runQuick, kill, resume, onStatusChange |
+| `api.terminal` | `terminal` | Spawn shells, read/write, ShellTerminal component |
+| `api.process` | `process` | Execute allowed CLI commands |
+| `api.ui` | `notifications` | Notices, errors, confirms, input dialogs |
+| `api.commands` | `commands` | Register/execute commands |
+| `api.events` | `events` | Subscribe to file:change and other events |
+| `api.settings` | `settings` | Read plugin settings, watch for changes |
+| `api.navigation` | `navigation` | Focus agents, switch tabs |
+| `api.widgets` | `widgets` | AgentTerminal, SleepingAgent, AgentAvatar, etc. |
+| `api.hub` | (none) | Refresh the hub |
+| `api.badges` | `badges` | Set/clear badge indicators on tabs |
+
+## Manifest Structure
+
+Every plugin needs a `manifest.json` with these required fields:
+
+```json
+{
+  "id": "my-plugin",
+  "name": "My Plugin",
+  "version": "0.1.0",
+  "description": "What it does",
+  "author": "Your Name",
+  "engine": { "api": 0.5 },
+  "scope": "project",
+  "main": "./dist/main.js",
+  "permissions": ["logging", "storage"],
+  "contributes": {
+    "tab": { "label": "My Tab", "icon": "<svg>...</svg>", "layout": "full" },
+    "help": { "topics": [{ "id": "overview", "title": "My Plugin", "content": "..." }] }
+  }
+}
+```
+
+## The `official` field
+
+The manifest supports an optional `official?: boolean` field. When `true`, it marks the plugin as maintained by Clubhouse Workshop. The app uses this to display trust indicators in the plugin browser.
+
+Community plugins should **omit this field** — it defaults to `false`/`undefined`. Only first-party plugins shipped in this repo should set `"official": true`.
+
+## Permissions (15 total)
+
+`logging`, `storage`, `notifications`, `files`, `files.external`, `git`, `agents`, `terminal`, `process`, `commands`, `events`, `settings`, `navigation`, `widgets`, `projects`, `badges`
+
+Plugins can only call APIs they've declared permissions for. Undeclared calls are blocked at runtime.
+
+## Storage Scopes
+
+| Scope | Visibility | Use for |
+|---|---|---|
+| `projectLocal` | Per-user, per-project, gitignored | Caches, UI state, drafts |
+| `project` | Per-project, committed | Shared team config |
+| `global` | Per-user, all projects | User preferences, history |
+
+All methods are async: `read(key)`, `write(key, value)`, `delete(key)`, `list()`.
+
+## Plugin Module Exports
+
+| Export | Required | Description |
+|---|---|---|
+| `activate(ctx, api)` | Yes | Setup: register commands, subscribe to events |
+| `deactivate()` | No | Cleanup (usually empty — subscriptions auto-dispose) |
+| `MainPanel({ api })` | No | Main UI component |
+| `SidebarPanel({ api })` | No | Sidebar component (sidebar-content layout) |
+| `SettingsPanel({ api })` | No | Custom settings UI |
+| `HubPanel(props)` | No | Hub panel content |
+
+## Common Patterns
+
+### Quick agent workflow
+```ts
+const result = await api.agents.runQuick("Summarize changes");
+```
+
+### Storage with defaults
+```ts
+const data = await api.storage.global.read("key") as MyType ?? defaults;
+await api.storage.global.write("key", data);
+```
+
+### Command registration
+```ts
+ctx.subscriptions.push(api.commands.register("my-plugin.cmd", handler));
+```
+
+### Subscription cleanup
+```ts
+ctx.subscriptions.push(api.agents.onStatusChange(callback));
+```
+
+## Build System
+
+Standard esbuild configuration:
+```bash
+esbuild src/main.tsx --bundle --format=esm --platform=browser --external:react --outfile=dist/main.js
+```
+
+Dev dependencies: `@clubhouse/plugin-types`, `@types/react`, `esbuild`, `typescript`, `vitest`, `@clubhouse/plugin-testing`
+
+No runtime dependencies — React is provided by the app.
+
+## Testing
+
+Use `@clubhouse/plugin-testing`:
+- `createMockAPI(overrides?)` — fully-stubbed API with in-memory storage
+- `createMockContext(options?)` — context with sensible defaults
+- `renderPlugin(module, options?)` — activate + prepare MainPanel
+- `createMockAgents(api, agents)` — pre-populate agent list
+
+## Development Workflow
+
+1. `npx create-clubhouse-plugin` — scaffold
+2. `npm install && npm run build` — build
+3. `ln -s "$(pwd)" ~/.clubhouse/plugins/<id>` — symlink
+4. Enable in Settings > Plugins
+5. `npm run watch` — auto-rebuild on save
+6. `npm run typecheck` — catch type errors
+7. `npm test` — run unit tests
+
+## Documentation Files
+
+For detailed information, refer to these files in the repository:
+
+- `docs/getting-started.md` — 5-minute quickstart
+- `docs/api-reference.md` — every API method with examples
+- `docs/manifest-reference.md` — every manifest field explained
+- `docs/patterns.md` — cookbook-style recipes
+- `docs/faq.md` — common questions answered
+- `docs/quality-guidelines.md` — best practices
+- `wiki/` — extended documentation (GitHub Wiki-ready)
+- `sdk/plugin-types/index.d.ts` — the complete type definitions (source of truth)
+- `plugins/example-hello-world/` — minimal working example
+- `plugins/code-review/` — agent-powered example
+- `plugins/standup/` — app-scoped cross-project example
+- `plugins/pomodoro/` — timer with state management example
+
+## Tone
+
+Be helpful, clear, and encouraging. Use plain language. When in doubt, point to a working example in the `plugins/` directory — code speaks louder than explanations.

--- a/.claude/skills/scaffold-plugin/SKILL.md
+++ b/.claude/skills/scaffold-plugin/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: scaffold-plugin
+description: Interactively help a developer scaffold a new Clubhouse plugin from scratch. Use when someone wants to create a new plugin, start a plugin project, or asks about getting started building for Clubhouse.
+argument-hint: "[plugin-name]"
+---
+
+# Scaffold a Clubhouse Plugin
+
+You are a friendly, encouraging guide helping a developer create their first (or next) Clubhouse plugin. Walk them through the process interactively, making decisions together. Keep the tone welcoming — this should feel easy and fun, not intimidating.
+
+## Step 1: Understand what they want to build
+
+Ask the developer what they'd like their plugin to do. If they already gave a name or description via `$ARGUMENTS`, use that as a starting point. If not, ask:
+
+- What should the plugin do? (Even a rough idea is fine!)
+- What should it be called?
+
+Be encouraging — even simple ideas make great first plugins.
+
+## Step 2: Help them choose a scope
+
+Explain the three scopes in plain language and help them pick:
+
+- **project** — "Your plugin lives in a project tab. It works with one project at a time. This is the most common choice and the best place to start."
+- **app** — "Your plugin lives in the sidebar and can see all your projects. Use this for cross-project tools like standup summaries."
+- **dual** — "Works in both places. You probably don't need this yet."
+
+Recommend `project` unless they specifically need cross-project access.
+
+## Step 3: Help them pick permissions
+
+Based on what they described, suggest the minimum permissions they'll need. Always include `logging` and `storage`. Explain each one in a sentence:
+
+- `logging` — see debug messages in the plugin console
+- `storage` — save data that persists across sessions
+- `notifications` — show toast messages and dialogs
+- `files` — read/write files in the project
+- `git` — read git status, log, diff, branches
+- `agents` — spawn AI agents to do work
+- `terminal` — create shell sessions
+- `process` — run specific CLI tools (eslint, etc.)
+- `commands` — register keyboard shortcuts
+- `events` — react to file changes
+- `settings` — user-configurable options
+- `navigation` — programmatically switch tabs/focus agents
+- `widgets` — use shared UI components (AgentTerminal, etc.)
+- `projects` — access all projects (needs app/dual scope)
+- `badges` — show notification badges on tabs
+
+## Step 4: Create the plugin
+
+Generate the plugin files. Create a new directory at the project root with the plugin name (lowercased, hyphenated). Generate these files:
+
+### manifest.json
+
+Based on their choices. Use API version `0.5`. Include a `contributes.help` topic. Use a simple SVG icon. Do NOT include `"official": true` — that field is reserved for first-party plugins maintained by Clubhouse Workshop.
+
+### package.json
+
+```json
+{
+  "name": "<plugin-id>",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "esbuild src/main.tsx --bundle --format=esm --platform=browser --external:react --outfile=dist/main.js",
+    "watch": "esbuild src/main.tsx --bundle --format=esm --platform=browser --external:react --outfile=dist/main.js --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@clubhouse/plugin-types": "^0.5.0",
+    "@clubhouse/plugin-testing": "^0.5.0",
+    "@types/react": "^19.0.0",
+    "esbuild": "^0.24.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}
+```
+
+### tsconfig.json
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "declaration": false,
+    "noEmit": true
+  },
+  "include": ["src"]
+}
+```
+
+### .gitignore
+
+```
+node_modules/
+dist/
+```
+
+### src/main.tsx
+
+Write a starter implementation that matches what they described. Always follow these rules:
+
+1. **Use `globalThis.React`** — never `import React from 'react'`
+2. **Export `activate`** — log a startup message, register any commands
+3. **Export `MainPanel`** — a simple UI showing their plugin's functionality
+4. **Use inline styles** — with CSS custom properties for theming (`var(--font-family)`, `var(--text-secondary)`, etc.)
+5. **Import types only** — `import type { ... } from "@clubhouse/plugin-types"`
+6. **Keep it simple** — working code they can build on, not a complex starter
+
+If they want agents, include a `runQuick` example. If they want storage, show read/write. Make the UI look nice with padding, spacing, and readable typography.
+
+## Step 5: Tell them the next steps
+
+After creating the files, tell them:
+
+```
+Next steps:
+
+  cd <plugin-name>
+  npm install
+  npm run build
+
+To install for development:
+
+  ln -s "$(pwd)" ~/.clubhouse/plugins/<plugin-id>
+
+Then enable in Clubhouse: Settings > Plugins > <Plugin Name>
+
+For live development, use: npm run watch
+```
+
+## Important patterns to follow
+
+- Always use `const React = globalThis.React;` at the top of main.tsx
+- Always destructure hooks: `const { useState, useEffect, useCallback } = React;`
+- Always push disposables to `ctx.subscriptions`
+- Always handle errors in async operations with try/catch
+- Type the component props as `PanelProps` from `@clubhouse/plugin-types`
+- Use `api.logging.info()` in activate to confirm the plugin loaded
+- Keep the initial implementation small and working — they can iterate from there
+
+## Tone
+
+Be warm, encouraging, and practical. Celebrate their plugin idea. If they seem unsure, suggest simple starting points. Make them feel like building a plugin is something they can absolutely do.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,254 @@
+# Clubhouse Workshop
+
+**Build plugins for Clubhouse in minutes.** This repo has everything you need: an SDK with full TypeScript types, a scaffolding CLI, example plugins, and docs to guide you from zero to published.
+
+Whether you're a seasoned developer or just getting started, you're in the right place. Welcome!
+
+---
+
+## Quick Start
+
+### 1. Clone the repo
+
+```bash
+git clone https://github.com/masra91/Clubhouse-Workshop.git
+cd Clubhouse-Workshop
+```
+
+### 2. Try an example plugin
+
+The fastest way to see a plugin in action — no build step needed:
+
+```bash
+# Copy the hello-world example to your plugins folder
+cp -r plugins/example-hello-world ~/.clubhouse/plugins/
+```
+
+Then open Clubhouse, go to **Settings > Plugins**, find **Hello World**, and toggle it on. You'll see a new **Hello** tab in any project.
+
+### 3. Build your own
+
+```bash
+# Scaffold a new plugin interactively
+npx create-clubhouse-plugin
+```
+
+This walks you through naming your plugin, choosing a scope, picking permissions, and selecting a starter template. When it's done:
+
+```bash
+cd my-plugin
+npm install
+npm run build
+```
+
+Link it for development:
+
+```bash
+ln -s "$(pwd)" ~/.clubhouse/plugins/my-plugin
+```
+
+Enable it in **Settings > Plugins** — that's it!
+
+---
+
+## What's in this repo
+
+```
+Clubhouse-Workshop/
+  sdk/
+    plugin-types/         TypeScript types for the plugin API
+    plugin-testing/       Mocks & test harness for unit testing
+  create-clubhouse-plugin/  Scaffolding CLI (npx create-clubhouse-plugin)
+  plugins/
+    example-hello-world/  Minimal starter — counter, storage, notifications
+    code-review/          AI-powered code review via quick agents
+    standup/              Cross-project standup generator (app-scoped)
+    pomodoro/             Focus timer with session tracking
+  docs/                   Detailed guides and references
+  registry/               Plugin registry catalog
+```
+
+---
+
+## Documentation
+
+| Guide | What you'll learn |
+|---|---|
+| [Getting Started](docs/getting-started.md) | Install, build, and run your first plugin in 5 minutes |
+| [Scaffolding Guide](https://github.com/masra91/Clubhouse-Workshop/wiki/Scaffolding-Guide) | Use the CLI to generate any type of plugin |
+| [API Reference](https://github.com/masra91/Clubhouse-Workshop/wiki/API-Reference) | Every method on the plugin API with examples |
+| [Manifest Reference](https://github.com/masra91/Clubhouse-Workshop/wiki/Manifest-Reference) | Every field in `manifest.json` explained |
+| [Plugin Patterns](https://github.com/masra91/Clubhouse-Workshop/wiki/Plugin-Patterns) | Recipes for agents, storage, commands, and more |
+| [FAQ](https://github.com/masra91/Clubhouse-Workshop/wiki/FAQ) | Common questions answered |
+| [Quality Guidelines](https://github.com/masra91/Clubhouse-Workshop/wiki/Quality-Guidelines) | Best practices for reliable, trustworthy plugins |
+
+---
+
+## Claude Code Skills
+
+If you're using [Claude Code](https://claude.com/claude-code), this repo ships with built-in skills that make plugin development even easier. Just open the repo in Claude Code and use:
+
+| Skill | What it does |
+|---|---|
+| `/scaffold-plugin` | Interactively walks you through creating a new plugin — picks scope, permissions, and generates all the files with working starter code |
+| `/plugin-guide` | Answers questions about the plugin system — architecture, API, manifest, patterns. Ask "how do agents work?" and it knows the answer |
+
+`/scaffold-plugin` is great for beginners — it asks what you want to build and does the rest. `/plugin-guide` loads automatically when you ask Claude questions about the Clubhouse plugin system, so you can just ask naturally.
+
+These skills live in `.claude/skills/` and work automatically when you open this repo.
+
+---
+
+## Plugin Architecture at a Glance
+
+Plugins are **ES modules** that Clubhouse loads at runtime. Each plugin has:
+
+- **`manifest.json`** — declares identity, permissions, and UI contributions
+- **`dist/main.js`** — your bundled code (built with esbuild)
+- **`activate(ctx, api)`** — entry point called when the plugin loads
+- **Panel components** — React components for your plugin's UI
+
+```
+                  ┌──────────────────────────┐
+                  │       Clubhouse App       │
+                  │                           │
+  ┌───────────┐   │  ┌─────────────────────┐  │
+  │ manifest  │──▶│  │  Plugin Loader       │  │
+  │  .json    │   │  │  ─ validate manifest │  │
+  └───────────┘   │  │  ─ check permissions │  │
+                  │  │  ─ import(main.js)   │  │
+  ┌───────────┐   │  └────────┬────────────┘  │
+  │ dist/     │──▶│           │               │
+  │  main.js  │   │  ┌────────▼────────────┐  │
+  └───────────┘   │  │  activate(ctx, api)  │  │
+                  │  │  MainPanel({ api })  │  │
+                  │  │  SidebarPanel, etc.  │  │
+                  │  └─────────────────────┘  │
+                  └──────────────────────────┘
+```
+
+Plugins access Clubhouse through a sandboxed `PluginAPI` — only methods you've declared permissions for are available. React is provided by the app via `globalThis.React` (no need to bundle it).
+
+---
+
+## Scaffolding Templates
+
+The `create-clubhouse-plugin` CLI offers four templates:
+
+| Template | Best for | What you get |
+|---|---|---|
+| **basic** | Simple tools, displays, dashboards | A `MainPanel` with logging and storage |
+| **with-sidebar** | List/detail interfaces | `SidebarPanel` + `MainPanel` side by side |
+| **app-scoped** | Cross-project tools | Rail item with access to all projects |
+| **agent-workflow** | AI-powered features | Quick agent spawning with status display |
+
+---
+
+## Example Plugins
+
+Each example is a complete, working plugin you can install immediately or use as a starting point.
+
+### Hello World
+The simplest possible plugin. A counter that persists across sessions, a command, and a notification. **Start here.**
+```bash
+cp -r plugins/example-hello-world ~/.clubhouse/plugins/
+```
+
+### Code Review
+Spawn an AI agent to review your staged changes or branch diff. Stores review history.
+```bash
+cp -r plugins/code-review ~/.clubhouse/plugins/
+```
+
+### Standup
+App-scoped plugin that generates daily standup summaries across all your projects.
+```bash
+cp -r plugins/standup ~/.clubhouse/plugins/
+```
+
+### Pomodoro
+Focus timer with 25-minute work / 5-minute break cycles. Tracks session history.
+```bash
+cp -r plugins/pomodoro ~/.clubhouse/plugins/
+```
+
+---
+
+## Development Workflow
+
+```bash
+# Create your plugin
+npx create-clubhouse-plugin
+
+# Install deps and build
+cd my-plugin && npm install && npm run build
+
+# Link for live development
+ln -s "$(pwd)" ~/.clubhouse/plugins/my-plugin
+
+# Watch for changes (rebuilds on save)
+npm run watch
+
+# Type-check your code
+npm run typecheck
+
+# Run tests
+npm test
+```
+
+After making changes, restart Clubhouse (or use plugin reload) to pick them up.
+
+### Debugging
+
+1. **Plugin logs** — Settings > Plugins > [Your Plugin] > Logs
+2. **DevTools** — View > Toggle Developer Tools (console.log works)
+3. **Dev mode** — Set `"dev": true` in your manifest for verbose API logging
+4. **Source maps** — Add `--sourcemap` to your esbuild command
+
+---
+
+## Testing Your Plugin
+
+The `@clubhouse/plugin-testing` package provides everything you need:
+
+```ts
+import { createMockAPI, createMockContext, renderPlugin } from "@clubhouse/plugin-testing";
+import * as myPlugin from "../src/main";
+
+test("activate registers commands", async () => {
+  const api = createMockAPI();
+  const ctx = createMockContext();
+  await myPlugin.activate(ctx, api);
+  expect(ctx.subscriptions.length).toBeGreaterThan(0);
+});
+```
+
+See the [Testing section](https://github.com/masra91/Clubhouse-Workshop/wiki/API-Reference#testing) in the API Reference for more.
+
+---
+
+## Contributing
+
+We'd love your contributions! Whether it's a new example plugin, a docs improvement, or a bug fix — all are welcome.
+
+1. Fork the repo
+2. Create a feature branch (`git checkout -b my-feature`)
+3. Make your changes
+4. Submit a pull request
+
+For plugin submissions to the registry, see the [Quality Guidelines](https://github.com/masra91/Clubhouse-Workshop/wiki/Quality-Guidelines).
+
+---
+
+## Resources
+
+- [Plugin Types SDK](sdk/plugin-types/) — `@clubhouse/plugin-types`
+- [Testing Utilities](sdk/plugin-testing/) — `@clubhouse/plugin-testing`
+- [Plugin Registry](registry/) — Machine-readable plugin catalog
+- [Design Principles](principles.md) — The philosophy behind the plugin system
+
+---
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

- **README.md** — Welcoming landing page with quick start, architecture diagram, scaffolding templates, example plugins, dev workflow, testing guide, and links to the GitHub Wiki
- **`/scaffold-plugin` Claude skill** — Interactively walks developers through creating a new plugin (picks scope, permissions, generates all files with working starter code)
- **`/plugin-guide` Claude skill** — Answers questions about the plugin system, architecture, API, manifest, and patterns. Loads automatically when relevant
- All wiki references link to the published GitHub Wiki at https://github.com/masra91/Clubhouse-Workshop/wiki
- Both skills document the new `official?: boolean` manifest field

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify wiki links resolve to published wiki pages
- [ ] Open repo in Claude Code and test `/scaffold-plugin` creates a working plugin
- [ ] Open repo in Claude Code and test `/plugin-guide` answers SDK questions accurately

🤖 Generated with [Claude Code](https://claude.com/claude-code)