### PR TITLE
Fix AgentInfo.emoji → icon to match app

### DIFF
--- a/sdk/plugin-types/index.d.ts
+++ b/sdk/plugin-types/index.d.ts
@@ -91,7 +91,7 @@ export interface AgentInfo {
   kind: AgentKind;
   status: AgentStatus;
   color: string;
-  emoji?: string;
+  icon?: string;
   exitCode?: number;
   mission?: string;
   projectId: string;


### PR DESCRIPTION
## Summary

- Rename `emoji?: string` to `icon?: string` on `AgentInfo` in the SDK types to match what the Clubhouse app actually provides

Without this fix, plugins accessing `agent.emoji` get `undefined` since the app maps the field as `icon`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)