### PR TITLE
Add missing commands permission to Standup and Hello World

### DIFF
--- a/plugins/example-hello-world/manifest.json
+++ b/plugins/example-hello-world/manifest.json
@@ -8,7 +8,7 @@
   "engine": { "api": 0.5 },
   "scope": "project",
   "main": "./dist/main.js",
-  "permissions": ["logging", "storage", "notifications"],
+  "permissions": ["logging", "storage", "notifications", "commands"],
   "contributes": {
     "tab": {
       "label": "Hello",

--- a/plugins/standup/manifest.json
+++ b/plugins/standup/manifest.json
@@ -8,7 +8,7 @@
   "engine": { "api": 0.5 },
   "scope": "app",
   "main": "./dist/main.js",
-  "permissions": ["logging", "storage", "notifications", "agents", "projects", "git"],
+  "permissions": ["logging", "storage", "notifications", "agents", "projects", "git", "commands"],
   "contributes": {
     "railItem": {
       "label": "Standup",


### PR DESCRIPTION
## Summary
- Both **Standup** and **Hello World** plugins register commands via `contributes.commands` but were missing `"commands"` in their `permissions` array
- This caused the app to disable both plugins at runtime with a permission error
- Adds the missing `commands` permission to both manifests

## Test plan
- [ ] Load Clubhouse with both plugins enabled
- [ ] Verify neither plugin shows a permission error
- [ ] Verify Standup's "Generate Standup" command works
- [ ] Verify Hello World's "Say Hello" command works

🤖 Generated with [Claude Code](https://claude.com/claude-code)