### PR TITLE
ci: add workflow_dispatch to release workflow

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -4,6 +4,11 @@ on:
   push:
     tags:
       - '*-v*'  # e.g., example-hello-world-v0.1.0, code-review-v1.0.0
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (e.g., code-review-v0.1.0)'
+        required: true
 
 permissions:
   contents: write
@@ -18,7 +23,13 @@ jobs:
       - name: Parse tag
         id: tag
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
+          if [ -n "${{ github.event.inputs.tag }}" ]; then
+            TAG="${{ github.event.inputs.tag }}"
+            git fetch --tags
+            git checkout "$TAG"
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+          fi
           # Extract plugin ID and version from tag like "code-review-v0.1.0"
           PLUGIN_ID=$(echo "$TAG" | sed 's/-v[0-9].*//')
           VERSION=$(echo "$TAG" | sed 's/.*-v//')


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to `release-plugin.yml` so releases can be manually triggered
- Tag push events aren't firing — this gives us a way to test and run releases via the Actions tab or `gh workflow run`

## Context
Tag pushes for `*-v*` aren't triggering the release workflow despite Actions being enabled. This adds a manual fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)