### PR TITLE
ci: fix release workflow for branch protection

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Install and build
         working-directory: ${{ steps.tag.outputs.plugin_dir }}
         run: |
-          npm ci
+          npm install
           npm run build
           if [ -f package.json ] && grep -q '"test"' package.json; then
             npm test || true
@@ -94,6 +94,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.tag.outputs.tag }}
           name: "${{ steps.tag.outputs.plugin_id }} v${{ steps.tag.outputs.version }}"
           body: |
             ## ${{ steps.tag.outputs.plugin_id }} v${{ steps.tag.outputs.version }}
@@ -149,6 +150,14 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b registry-update/${{ steps.tag.outputs.tag }}
           git add registry/registry.json
-          git diff --cached --quiet || git commit -m "registry: update ${{ steps.tag.outputs.plugin_id }} to v${{ steps.tag.outputs.version }}"
-          git push origin HEAD:main
+          git diff --cached --quiet && echo "No registry changes" && exit 0
+          git commit -m "registry: update ${{ steps.tag.outputs.plugin_id }} to v${{ steps.tag.outputs.version }}"
+          git push origin registry-update/${{ steps.tag.outputs.tag }}
+          gh pr create \
+            --title "registry: update ${{ steps.tag.outputs.plugin_id }} to v${{ steps.tag.outputs.version }}" \
+            --body "Automated registry update from release workflow." \
+            --base main
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- `npm ci` → `npm install` (plugins don't have lock files)
- Add explicit `tag_name` to GitHub Release step (required when triggered via `workflow_dispatch`)
- Registry update now creates a PR instead of pushing directly to main (branch protection blocks direct pushes)

## Context
First attempt at `workflow_dispatch` for `example-hello-world-v0.1.0` failed on `npm ci`. These fixes address that + the downstream issues we'd hit next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)