### PR TITLE
ci: force push registry branch to handle reruns

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -154,7 +154,7 @@ jobs:
           git add registry/registry.json
           git diff --cached --quiet && echo "No registry changes" && exit 0
           git commit -m "registry: update ${{ steps.tag.outputs.plugin_id }} to v${{ steps.tag.outputs.version }}"
-          git push origin registry-update/${{ steps.tag.outputs.tag }}
+          git push --force origin registry-update/${{ steps.tag.outputs.tag }}
           gh pr create \
             --title "registry: update ${{ steps.tag.outputs.plugin_id }} to v${{ steps.tag.outputs.version }}" \
             --body "Automated registry update from release workflow." \


### PR DESCRIPTION
## Summary
- Use `--force` when pushing the registry update branch so workflow reruns don't fail with "non-fast-forward" errors

## Context
All 4 releases were created successfully but the registry update PRs failed because the branches already existed from previous attempts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)