### PR TITLE
ci: add pull-requests permission to release workflow

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   release:


### PR DESCRIPTION
## Summary
- Add `pull-requests: write` to the workflow permissions block
- When `permissions` is explicitly set, only listed scopes are granted — `pull-requests` was missing, causing `gh pr create` to fail with "Resource not accessible by integration"

🤖 Generated with [Claude Code](https://claude.com/claude-code)