### PR TITLE
registry: update all plugins to v0.1.0

### DIFF
--- a/registry/registry.json
+++ b/registry/registry.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated": "2026-02-18T00:00:00Z",
+  "updated": "2026-02-21T22:50:00Z",
   "plugins": [
     {
       "id": "example-hello-world",
@@ -16,9 +16,9 @@
         "0.1.0": {
           "api": 0.5,
           "asset": "https://github.com/Agent-Clubhouse/Clubhouse-Workshop/releases/download/example-hello-world-v0.1.0/example-hello-world-v0.1.0.zip",
-          "sha256": "",
-          "permissions": ["logging", "storage", "notifications"],
-          "size": 0
+          "sha256": "e772faf55bf613252c69b7d072776a0d60cb285d8ccf980bb5e4d678c062c743",
+          "permissions": ["logging", "storage", "notifications", "commands"],
+          "size": 3116
         }
       }
     },
@@ -36,9 +36,9 @@
         "0.1.0": {
           "api": 0.5,
           "asset": "https://github.com/Agent-Clubhouse/Clubhouse-Workshop/releases/download/code-review-v0.1.0/code-review-v0.1.0.zip",
-          "sha256": "",
-          "permissions": ["logging", "storage", "notifications", "files", "git", "agents", "commands"],
-          "size": 0
+          "sha256": "f4a0a01ae1929a86f7a69e0699f045f7da057212b5e1262ab04a4d42ae5a9587",
+          "permissions": ["logging", "storage", "notifications", "files", "git", "agents", "commands", "process"],
+          "size": 4654
         }
       }
     },
@@ -56,9 +56,9 @@
         "0.1.0": {
           "api": 0.5,
           "asset": "https://github.com/Agent-Clubhouse/Clubhouse-Workshop/releases/download/standup-v0.1.0/standup-v0.1.0.zip",
-          "sha256": "",
-          "permissions": ["logging", "storage", "notifications", "agents", "projects", "git"],
-          "size": 0
+          "sha256": "644306c64e34e8268d1d3ccd4e0cbf5d07ffaf1cbb7ac27cc3e2d8b9260174ae",
+          "permissions": ["logging", "storage", "notifications", "agents", "projects", "git", "commands"],
+          "size": 3851
         }
       }
     },
@@ -76,9 +76,9 @@
         "0.1.0": {
           "api": 0.5,
           "asset": "https://github.com/Agent-Clubhouse/Clubhouse-Workshop/releases/download/pomodoro-v0.1.0/pomodoro-v0.1.0.zip",
-          "sha256": "",
+          "sha256": "f7a7ece9c90e2830ec8458f32d7190b6aa70dfb8e71ec9c10120c2dc527f014b",
           "permissions": ["logging", "storage", "notifications", "commands", "widgets"],
-          "size": 0
+          "size": 3713
         }
       }
     }


### PR DESCRIPTION
## Summary
- Populates sha256, size, and permissions for all 4 plugin releases
- Data sourced from the automated release workflow runs

| Plugin | sha256 | Size |
|--------|--------|------|
| example-hello-world | `e772fa...` | 3,116 B |
| code-review | `f4a0a0...` | 4,654 B |
| standup | `644306...` | 3,851 B |
| pomodoro | `f7a7ec...` | 3,713 B |

Replaces closed PRs #18, #19, #20, #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)