### PR TITLE
docs: update release process to match actual workflow

### DIFF
--- a/registry/README.md
+++ b/registry/README.md
@@ -16,23 +16,31 @@ cd plugins/my-plugin
 # edit manifest.json: bump "version"
 # edit package.json: bump "version"
 
-# 2. Build and test
+# 2. Build and test locally
 npm run build
 npm test
 
-# 3. Commit the version bump
+# 3. Commit the version bump (via PR — branch protection requires it)
+git checkout -b my-plugin/v1.0.0
 git add -A && git commit -m "my-plugin: bump to v1.0.0"
+git push origin my-plugin/v1.0.0
+# Open and merge a PR
 
-# 4. Tag the release
-git tag my-plugin-v1.0.0
-git push origin main --tags
+# 4. Tag the release on main
+git checkout main && git pull
+git tag -m "Release my-plugin v1.0.0" my-plugin-v1.0.0
+git push origin my-plugin-v1.0.0
+```
 
-# 5. CI handles the rest:
-#    - Builds the plugin
-#    - Validates the manifest
-#    - Creates a zip artifact
-#    - Creates a GitHub Release
-#    - Updates registry.json with the new version
+CI handles the rest:
+1. Builds the plugin and validates the manifest
+2. Creates a zip artifact and GitHub Release
+3. Opens a PR to update `registry.json` with the new version's sha256, size, and permissions
+4. Merge the registry PR to complete the release
+
+You can also trigger a release manually:
+```bash
+gh workflow run "Release Plugin" -f tag=my-plugin-v1.0.0
 ```
 
 ## Registry format

--- a/workshop/P2-registry-and-releases.md
+++ b/workshop/P2-registry-and-releases.md
@@ -60,21 +60,22 @@
 
 **Path:** `.github/workflows/release-plugin.yml`
 
-**Trigger:** Push a git tag matching `<plugin-id>-v*` (e.g., `example-hello-world-v0.1.0`)
+**Triggers:**
+- Push a git tag matching `<plugin-id>-v*` (e.g., `example-hello-world-v0.1.0`)
+- Manual dispatch: `gh workflow run "Release Plugin" -f tag=<tag>`
 
 **Steps:**
-1. Checkout the repo
+1. Checkout the repo (for manual dispatch, checkout the tag)
 2. Navigate to the plugin directory (`plugins/<plugin-id>/`)
-3. `npm ci && npm run build && npm test`
+3. `npm install && npm run build && npm test`
 4. Validate the manifest (run the same validation the app does)
 5. Create a zip containing: `manifest.json`, `dist/main.js`, `README.md` (and any other declared assets)
 6. Compute sha256 of the zip
 7. Create a GitHub Release with the zip attached
-8. Update `registry/registry.json`:
+8. Open a PR to update `registry/registry.json`:
    - Add or update the plugin entry
-   - Set the new version's asset URL, sha256, permissions
+   - Set the new version's asset URL, sha256, permissions, size
    - Update `latest` field
-9. Commit and push the registry update
 
 **Separate workflow for registry validation:**
 - On PR, validate that `registry.json` is valid JSON matching the schema
@@ -92,10 +93,12 @@ For first-party plugins developed in this repo:
 # 1. Update the plugin version in manifest.json and package.json
 # 2. Build and test
 cd plugins/my-plugin && npm run build && npm test
-# 3. Tag the release
-git tag my-plugin-v1.0.0
+# 3. Commit via PR (branch protection requires it)
+# 4. Tag the release on main
+git tag -m "Release my-plugin v1.0.0" my-plugin-v1.0.0
 git push origin my-plugin-v1.0.0
-# 4. CI handles the rest
+# 5. CI creates a GitHub Release and opens a registry update PR
+# 6. Merge the registry PR
 ```
 
 ---


### PR DESCRIPTION
## Summary
- `registry/README.md`: Updated release steps to reflect branch protection (PRs for version bumps), registry updates via PR instead of direct push, and `workflow_dispatch` manual trigger
- `workshop/P2-registry-and-releases.md`: Same updates — `npm ci` → `npm install`, registry PR instead of direct commit, manual dispatch documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)