### PR TITLE
feat: scaffold KanBoss plugin from Clubhouse builtin

### DIFF
--- a/plugins/kanboss/.gitignore
+++ b/plugins/kanboss/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/plugins/kanboss/manifest.json
+++ b/plugins/kanboss/manifest.json
@@ -1,0 +1,44 @@
+{
+  "id": "kanboss",
+  "name": "KanBoss",
+  "version": "0.1.0",
+  "description": "Kanban boards with AI-powered automation. Create boards with customizable states and swimlanes, assign AI agents to automate work, and track card progress with labels, priorities, and WIP limits.",
+  "author": "Clubhouse Workshop",
+  "engine": { "api": 0.5 },
+  "scope": "project",
+  "main": "./dist/main.js",
+  "permissions": [
+    "logging",
+    "storage",
+    "agents",
+    "commands",
+    "notifications",
+    "navigation",
+    "widgets"
+  ],
+  "contributes": {
+    "tab": {
+      "label": "KanBoss",
+      "icon": "<svg width=\"18\" height=\"18\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><rect x=\"3\" y=\"3\" width=\"18\" height=\"18\" rx=\"2\"/><line x1=\"9\" y1=\"3\" x2=\"9\" y2=\"21\"/><line x1=\"15\" y1=\"3\" x2=\"15\" y2=\"21\"/><line x1=\"3\" y1=\"9\" x2=\"9\" y2=\"9\"/><line x1=\"15\" y1=\"9\" x2=\"21\" y2=\"9\"/></svg>",
+      "layout": "sidebar-content"
+    },
+    "commands": [
+      { "id": "refresh", "title": "Refresh Boards" },
+      { "id": "new-board", "title": "Create New Board" }
+    ],
+    "help": {
+      "topics": [
+        {
+          "id": "kanboss",
+          "title": "KanBoss",
+          "content": "## KanBoss\n\nProject-scoped Kanban boards with AI-powered automation.\n\n### Creating a board\nClick **+ New** in the sidebar to create a board. Each board starts with three states (Todo, In Progress, Done) and a Default swimlane.\n\n### Cards\nCards live at the intersection of a state (column) and swimlane (row). Click **+ Add** in any cell to create a card. Cards support labels for categorization and five priority levels.\n\n### Labels\nCreate colored labels to categorize cards (bug, feature, chore, etc.). Labels are defined per-board in board settings.\n\n### WIP Limits\nSet a maximum number of cards per column. When a column is at or over its limit, it's highlighted to help prevent bottlenecks.\n\n### Automation\nMark a state as **Automatic** and provide execution and evaluation prompts. When a card enters that state in a swimlane with an assigned durable agent, a quick agent is spawned to complete the task. A separate evaluation agent then checks the outcome using the evaluation prompt.\n\n### Zoom\nUse the zoom controls in the toolbar to scale the board view between 50% and 200%."
+        },
+        {
+          "id": "kanboss-automation",
+          "title": "KanBoss Automation",
+          "content": "## KanBoss Automation\n\nAutomation connects the Kanban workflow to AI agents.\n\n### Setup\n1. Open board settings (gear icon)\n2. Assign a durable agent as **manager** for a swimlane\n3. Mark a state as **Automatic** and write an execution prompt\n4. Optionally write a separate **evaluation prompt** for that state\n5. Set **Max Retries** (default: 3)\n\n### Flow\n1. Card enters an automatic state in a managed swimlane\n2. A quick agent executes the execution prompt\n3. An evaluation agent checks the outcome using the evaluation prompt\n4. On success: card advances to the next state\n5. On failure: card retries (up to max retries)\n6. If retries exhausted: card is marked **stuck**\n\n### Per-State Evaluation\nEach automatic state can have its own evaluation prompt, separate from the execution prompt. This lets you tailor the success criteria for each stage of your pipeline."
+        }
+      ]
+    }
+  }
+}

--- a/plugins/kanboss/package.json
+++ b/plugins/kanboss/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "kanboss",
+  "version": "0.1.0",
+  "private": true,
+  "license": "MIT",
+  "description": "Kanban boards with AI-powered automation for Clubhouse",
+  "scripts": {
+    "build": "esbuild src/main.tsx --bundle --format=esm --platform=browser --external:react --outfile=dist/main.js",
+    "watch": "esbuild src/main.tsx --bundle --format=esm --platform=browser --external:react --outfile=dist/main.js --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@clubhouse/plugin-types": "file:../../sdk/v0.5/plugin-types",
+    "@clubhouse/plugin-testing": "file:../../sdk/v0.5/plugin-testing",
+    "@types/react": "^19.0.0",
+    "esbuild": "^0.24.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/plugins/kanboss/src/AutomationEngine.ts
+++ b/plugins/kanboss/src/AutomationEngine.ts
@@ -1,0 +1,268 @@
+import type { PluginAPI, Disposable } from '@clubhouse/plugin-types';
+import type { Card, Board, AutomationRun } from './types';
+import { BOARDS_KEY, cardsKey, AUTOMATION_RUNS_KEY } from './types';
+import { kanBossState } from './state';
+
+// ── Module-level engine state ───────────────────────────────────────────
+
+let engineApi: PluginAPI | null = null;
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+async function loadBoard(api: PluginAPI, boardId: string): Promise<Board | null> {
+  const raw = await api.storage.projectLocal.read(BOARDS_KEY);
+  const boards: Board[] = Array.isArray(raw) ? raw : [];
+  return boards.find((b) => b.id === boardId) ?? null;
+}
+
+function cardsStor(api: PluginAPI, board: Board) {
+  return board.config.gitHistory ? api.storage.project : api.storage.projectLocal;
+}
+
+async function loadCards(api: PluginAPI, board: Board): Promise<Card[]> {
+  const raw = await cardsStor(api, board).read(cardsKey(board.id));
+  return Array.isArray(raw) ? raw : [];
+}
+
+async function saveCards(api: PluginAPI, board: Board, cards: Card[]): Promise<void> {
+  await cardsStor(api, board).write(cardsKey(board.id), cards);
+}
+
+async function loadRuns(api: PluginAPI): Promise<AutomationRun[]> {
+  const raw = await api.storage.projectLocal.read(AUTOMATION_RUNS_KEY);
+  return Array.isArray(raw) ? raw : [];
+}
+
+async function saveRuns(api: PluginAPI, runs: AutomationRun[]): Promise<void> {
+  await api.storage.projectLocal.write(AUTOMATION_RUNS_KEY, runs);
+}
+
+function addHistory(card: Card, action: Card['history'][0]['action'], detail: string, agentId?: string): void {
+  card.history.push({ action, timestamp: Date.now(), detail, agentId });
+  card.updatedAt = Date.now();
+}
+
+// ── Trigger automation for a card ───────────────────────────────────────
+
+export async function triggerAutomation(api: PluginAPI, card: Card, board: Board): Promise<void> {
+  const state = board.states.find((s) => s.id === card.stateId);
+  if (!state || !state.isAutomatic) return;
+
+  const swimlane = board.swimlanes.find((l) => l.id === card.swimlaneId);
+  if (!swimlane || !swimlane.managerAgentId) return;
+
+  if (card.automationAttempts >= board.config.maxRetries) {
+    return;
+  }
+
+  const prompt = [
+    'You are working on a Kanban card task. Complete the following outcome:',
+    '',
+    `OUTCOME: ${state.automationPrompt}`,
+    '',
+    `CARD TITLE: ${card.title}`,
+    `CARD DESCRIPTION: ${card.body}`,
+    '',
+    'Complete the work needed to satisfy the outcome above. Focus only on completing the task.',
+    'When done, provide a summary of what you accomplished.',
+  ].join('\n');
+
+  try {
+    const executionAgentId = await api.agents.runQuick(prompt);
+
+    // Record run
+    const configuredEvalAgent = swimlane.evaluationAgentId ?? swimlane.managerAgentId;
+    const runs = await loadRuns(api);
+    runs.push({
+      cardId: card.id,
+      boardId: board.id,
+      stateId: card.stateId,
+      swimlaneId: card.swimlaneId,
+      executionAgentId,
+      evaluationAgentId: null,
+      configuredEvaluationAgentId: configuredEvalAgent,
+      phase: 'executing',
+      attempt: card.automationAttempts + 1,
+      startedAt: Date.now(),
+    });
+    await saveRuns(api, runs);
+
+    // Update card
+    const cards = await loadCards(api, board);
+    const idx = cards.findIndex((c) => c.id === card.id);
+    if (idx !== -1) {
+      cards[idx].automationAttempts++;
+      addHistory(cards[idx], 'automation-started',
+        `Automation attempt ${cards[idx].automationAttempts} started`, executionAgentId);
+      await saveCards(api, board, cards);
+    }
+
+    kanBossState.triggerRefresh();
+  } catch {
+    api.logging.warn('KanBoss: Failed to spawn execution agent', { cardId: card.id });
+  }
+}
+
+// ── Handle agent completion ─────────────────────────────────────────────
+
+async function onAgentCompleted(api: PluginAPI, agentId: string, outcome: 'success' | 'error'): Promise<void> {
+  const runs = await loadRuns(api);
+  const runIdx = runs.findIndex((r) =>
+    (r.executionAgentId === agentId && r.phase === 'executing') ||
+    (r.evaluationAgentId === agentId && r.phase === 'evaluating')
+  );
+  if (runIdx === -1) return;
+
+  const run = runs[runIdx];
+  const board = await loadBoard(api, run.boardId);
+  if (!board) return;
+
+  const cards = await loadCards(api, board);
+  const cardIdx = cards.findIndex((c) => c.id === run.cardId);
+  if (cardIdx === -1) return;
+
+  const card = cards[cardIdx];
+
+  if (run.phase === 'executing') {
+    if (outcome === 'error') {
+      addHistory(card, 'automation-failed', 'Execution agent errored', agentId);
+      checkStuck(card, board);
+      runs.splice(runIdx, 1);
+      await saveRuns(api, runs);
+      await saveCards(api, board, cards);
+      kanBossState.triggerRefresh();
+      return;
+    }
+
+    // Execution succeeded — spawn evaluation agent
+    const completed = api.agents.listCompleted();
+    const info = completed.find((c) => c.id === agentId);
+
+    const state = board.states.find((s) => s.id === run.stateId);
+    if (!state) return;
+
+    // Use per-state evaluation prompt if provided, otherwise fall back to execution prompt
+    const evalCriteria = state.evaluationPrompt?.trim()
+      ? state.evaluationPrompt
+      : state.automationPrompt;
+
+    const evalPrompt = [
+      'Evaluate whether this outcome has been met:',
+      '',
+      `OUTCOME: ${evalCriteria}`,
+      '',
+      `CARD: ${card.title} — ${card.body}`,
+      '',
+      `AGENT SUMMARY: ${info?.summary ?? 'No summary available'}`,
+      `FILES MODIFIED: ${info?.filesModified?.join(', ') ?? 'None'}`,
+      '',
+      'Respond with EXACTLY one of:',
+      'RESULT: PASS',
+      'RESULT: FAIL',
+      '',
+      'Followed by a brief explanation.',
+    ].join('\n');
+
+    try {
+      const evalAgentId = await api.agents.runQuick(evalPrompt);
+      runs[runIdx] = { ...run, evaluationAgentId: evalAgentId, phase: 'evaluating' };
+      await saveRuns(api, runs);
+    } catch {
+      addHistory(card, 'automation-failed', 'Failed to spawn evaluation agent', agentId);
+      checkStuck(card, board);
+      runs.splice(runIdx, 1);
+      await saveRuns(api, runs);
+      await saveCards(api, board, cards);
+      kanBossState.triggerRefresh();
+    }
+    return;
+  }
+
+  // Phase: evaluating
+  if (run.phase === 'evaluating') {
+    const completed = api.agents.listCompleted();
+    const info = completed.find((c) => c.id === agentId);
+
+    const summary = info?.summary ?? '';
+    const passed = summary.includes('RESULT: PASS');
+
+    runs.splice(runIdx, 1);
+    await saveRuns(api, runs);
+
+    if (passed) {
+      // Move card to next state
+      const currentState = board.states.find((s) => s.id === card.stateId);
+      if (!currentState) return;
+
+      const sortedStates = [...board.states].sort((a, b) => a.order - b.order);
+      const nextStateIdx = sortedStates.findIndex((s) => s.id === currentState.id) + 1;
+
+      if (nextStateIdx < sortedStates.length) {
+        const nextState = sortedStates[nextStateIdx];
+        card.stateId = nextState.id;
+        card.automationAttempts = 0;
+        addHistory(card, 'automation-succeeded',
+          `Automation passed — moved to "${nextState.name}"`, agentId);
+        addHistory(card, 'moved', `Moved from "${currentState.name}" to "${nextState.name}"`);
+        await saveCards(api, board, cards);
+        kanBossState.triggerRefresh();
+
+        // If next state is also automatic, trigger recursively
+        if (nextState.isAutomatic) {
+          const freshCards = await loadCards(api, board);
+          const freshCard = freshCards.find((c) => c.id === card.id);
+          if (freshCard) {
+            await triggerAutomation(api, freshCard, board);
+          }
+        }
+      } else {
+        addHistory(card, 'automation-succeeded', 'Automation passed (already at final state)', agentId);
+        await saveCards(api, board, cards);
+        kanBossState.triggerRefresh();
+      }
+    } else {
+      const reason = summary.replace(/RESULT:\s*FAIL\s*/i, '').trim() || 'Evaluation failed';
+      addHistory(card, 'automation-failed', `Automation failed: ${reason}`, agentId);
+      checkStuck(card, board);
+      await saveCards(api, board, cards);
+      kanBossState.triggerRefresh();
+
+      // Retry if not stuck
+      if (card.automationAttempts < board.config.maxRetries) {
+        await triggerAutomation(api, card, board);
+      }
+    }
+  }
+}
+
+function checkStuck(card: Card, board: Board): void {
+  if (card.automationAttempts >= board.config.maxRetries) {
+    addHistory(card, 'automation-stuck',
+      `Card stuck after ${card.automationAttempts} attempts (max: ${board.config.maxRetries})`);
+  }
+}
+
+// ── Initialize / Shutdown ───────────────────────────────────────────────
+
+export function initAutomationEngine(api: PluginAPI): Disposable {
+  engineApi = api;
+
+  const statusSub = api.agents.onStatusChange((agentId, status, prevStatus) => {
+    if (!engineApi) return;
+
+    const isCompleted =
+      (prevStatus === 'running' && status === 'sleeping') ||
+      (prevStatus === 'running' && status === 'error');
+
+    if (!isCompleted) return;
+
+    const outcome = status === 'sleeping' ? 'success' as const : 'error' as const;
+    onAgentCompleted(engineApi, agentId, outcome);
+  });
+
+  return statusSub;
+}
+
+export function shutdownAutomationEngine(): void {
+  engineApi = null;
+}

--- a/plugins/kanboss/src/BoardConfigDialog.tsx
+++ b/plugins/kanboss/src/BoardConfigDialog.tsx
@@ -1,0 +1,556 @@
+const React = globalThis.React;
+const { useState, useCallback, useEffect } = React;
+
+import type { PluginAPI, AgentInfo } from '@clubhouse/plugin-types';
+import type { Board, BoardState, Swimlane, Label } from './types';
+import { BOARDS_KEY, generateId, LABEL_COLORS } from './types';
+import { kanBossState } from './state';
+import * as S from './styles';
+
+interface BoardConfigDialogProps {
+  api: PluginAPI;
+  board: Board;
+}
+
+type ConfigTab = 'states' | 'swimlanes' | 'labels' | 'settings';
+
+export function BoardConfigDialog({ api, board }: BoardConfigDialogProps) {
+  const storage = api.storage.projectLocal;
+  const [tab, setTab] = useState<ConfigTab>('states');
+
+  // Local copies for editing
+  const [states, setStates] = useState<BoardState[]>([...board.states]);
+  const [swimlanes, setSwimlanes] = useState<Swimlane[]>([...board.swimlanes]);
+  const [labels, setLabels] = useState<Label[]>([...(board.labels || [])]);
+  const [maxRetries, setMaxRetries] = useState(board.config.maxRetries);
+  const [gitHistory, setGitHistory] = useState(board.config.gitHistory ?? false);
+  const [durableAgents, setDurableAgents] = useState<AgentInfo[]>([]);
+
+  useEffect(() => {
+    const agents = api.agents.list().filter((a) => a.kind === 'durable');
+    setDurableAgents(agents);
+  }, [api]);
+
+  // ── State management ────────────────────────────────────────────────
+  const addState = useCallback(() => {
+    const order = states.length;
+    setStates([...states, {
+      id: generateId('state'),
+      name: `State ${order + 1}`,
+      order,
+      isAutomatic: false,
+      automationPrompt: '',
+      evaluationPrompt: '',
+      wipLimit: 0,
+    }]);
+  }, [states]);
+
+  const removeState = useCallback((stateId: string) => {
+    if (states.length <= 1) return;
+    const filtered = states.filter((s) => s.id !== stateId);
+    setStates(filtered.map((s, i) => ({ ...s, order: i })));
+  }, [states]);
+
+  const updateState = useCallback((stateId: string, updates: Partial<BoardState>) => {
+    setStates(states.map((s) => s.id === stateId ? { ...s, ...updates } : s));
+  }, [states]);
+
+  const moveState = useCallback((fromIdx: number, toIdx: number) => {
+    if (fromIdx === toIdx) return;
+    const result = [...states];
+    const [moved] = result.splice(fromIdx, 1);
+    result.splice(toIdx, 0, moved);
+    setStates(result.map((s, i) => ({ ...s, order: i })));
+  }, [states]);
+
+  // ── Swimlane management ─────────────────────────────────────────────
+  const addSwimlane = useCallback(() => {
+    const order = swimlanes.length;
+    setSwimlanes([...swimlanes, {
+      id: generateId('lane'),
+      name: `Swimlane ${order + 1}`,
+      order,
+      managerAgentId: null,
+      evaluationAgentId: null,
+    }]);
+  }, [swimlanes]);
+
+  const removeSwimlane = useCallback((laneId: string) => {
+    if (swimlanes.length <= 1) return;
+    const filtered = swimlanes.filter((l) => l.id !== laneId);
+    setSwimlanes(filtered.map((l, i) => ({ ...l, order: i })));
+  }, [swimlanes]);
+
+  const updateSwimlane = useCallback((laneId: string, updates: Partial<Swimlane>) => {
+    setSwimlanes(swimlanes.map((l) => l.id === laneId ? { ...l, ...updates } : l));
+  }, [swimlanes]);
+
+  const moveSwimlane = useCallback((fromIdx: number, toIdx: number) => {
+    if (fromIdx === toIdx) return;
+    const result = [...swimlanes];
+    const [moved] = result.splice(fromIdx, 1);
+    result.splice(toIdx, 0, moved);
+    setSwimlanes(result.map((l, i) => ({ ...l, order: i })));
+  }, [swimlanes]);
+
+  // ── Label management ──────────────────────────────────────────────
+  const addLabel = useCallback(() => {
+    const usedColors = labels.map((l) => l.color);
+    const nextColor = LABEL_COLORS.find((c) => !usedColors.includes(c)) || LABEL_COLORS[0];
+    setLabels([...labels, {
+      id: generateId('label'),
+      name: `Label ${labels.length + 1}`,
+      color: nextColor,
+    }]);
+  }, [labels]);
+
+  const removeLabel = useCallback((labelId: string) => {
+    setLabels(labels.filter((l) => l.id !== labelId));
+  }, [labels]);
+
+  const updateLabel = useCallback((labelId: string, updates: Partial<Label>) => {
+    setLabels(labels.map((l) => l.id === labelId ? { ...l, ...updates } : l));
+  }, [labels]);
+
+  // ── Save ────────────────────────────────────────────────────────────
+  const handleSave = useCallback(async () => {
+    const raw = await storage.read(BOARDS_KEY);
+    const boards: Board[] = Array.isArray(raw) ? raw : [];
+    const idx = boards.findIndex((b) => b.id === board.id);
+    if (idx !== -1) {
+      boards[idx] = {
+        ...boards[idx],
+        states,
+        swimlanes,
+        labels,
+        config: { ...boards[idx].config, maxRetries, gitHistory },
+        updatedAt: Date.now(),
+      };
+      await storage.write(BOARDS_KEY, boards);
+      kanBossState.setBoards(boards);
+    }
+    kanBossState.closeBoardConfig();
+    kanBossState.triggerRefresh();
+  }, [storage, board.id, states, swimlanes, labels, maxRetries, gitHistory]);
+
+  const handleCancel = useCallback(() => {
+    kanBossState.closeBoardConfig();
+  }, []);
+
+  // ── Tab button helper ───────────────────────────────────────────────
+  const tabBtn = (id: ConfigTab, label: string) => (
+    <button
+      key={id}
+      onClick={() => setTab(id)}
+      style={{
+        padding: '6px 12px',
+        fontSize: 12,
+        borderRadius: '8px 8px 0 0',
+        border: tab === id ? `1px solid ${S.color.border}` : 'none',
+        borderBottom: tab === id ? `1px solid ${S.color.bg}` : 'none',
+        marginBottom: tab === id ? -1 : 0,
+        background: tab === id ? S.color.bg : 'transparent',
+        color: tab === id ? S.color.text : S.color.textTertiary,
+        cursor: 'pointer',
+        fontFamily: S.font.family,
+      }}
+    >
+      {label}
+    </button>
+  );
+
+  return (
+    <div style={S.overlay} onClick={handleCancel}>
+      <div style={S.dialogWide} onClick={(e) => e.stopPropagation()}>
+        {/* Header */}
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '12px 16px',
+          borderBottom: `1px solid ${S.color.border}`,
+          fontFamily: S.font.family,
+        }}>
+          <span style={{ fontSize: 14, fontWeight: 500, color: S.color.text }}>
+            Board Settings: {board.name}
+          </span>
+          <button
+            onClick={handleCancel}
+            style={{ color: S.color.textTertiary, fontSize: 18, border: 'none', background: 'transparent', cursor: 'pointer' }}
+          >
+            {'\u00D7'}
+          </button>
+        </div>
+
+        {/* Tabs */}
+        <div style={{ display: 'flex', gap: 4, padding: '8px 16px 0', background: S.color.bgSecondary }}>
+          {tabBtn('states', 'States')}
+          {tabBtn('swimlanes', 'Swimlanes')}
+          {tabBtn('labels', 'Labels')}
+          {tabBtn('settings', 'Settings')}
+        </div>
+
+        {/* Tab content */}
+        <div style={{ flex: 1, overflowY: 'auto', padding: 16, fontFamily: S.font.family }}>
+
+          {/* ── States tab ──────────────────────────────────────────────── */}
+          {tab === 'states' && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+              {states.map((state, idx) => (
+                <div
+                  key={state.id}
+                  draggable
+                  onDragStart={(e) => e.dataTransfer.setData('kanboss/state-idx', String(idx))}
+                  onDragOver={(e) => e.preventDefault()}
+                  onDrop={(e) => {
+                    e.preventDefault();
+                    const from = e.dataTransfer.getData('kanboss/state-idx');
+                    if (from !== '') moveState(parseInt(from), idx);
+                  }}
+                  style={{
+                    padding: 12,
+                    background: S.color.bgSecondary,
+                    border: `1px solid ${S.color.border}`,
+                    borderRadius: 10,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 8,
+                  }}
+                >
+                  {/* Name row */}
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                    <span style={{ color: S.color.textTertiary, cursor: 'grab', fontSize: 12, userSelect: 'none' }} title="Drag to reorder">{'\u2261'}</span>
+                    <input
+                      type="text"
+                      value={state.name}
+                      onChange={(e) => updateState(state.id, { name: e.target.value })}
+                      style={{ ...S.baseInput, flex: 1 }}
+                    />
+                    {/* WIP limit */}
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexShrink: 0 }}>
+                      <label style={{ fontSize: 10, color: S.color.textTertiary, whiteSpace: 'nowrap' }}>WIP</label>
+                      <input
+                        type="number"
+                        min={0}
+                        max={99}
+                        value={state.wipLimit}
+                        onChange={(e) => updateState(state.id, { wipLimit: Math.max(0, parseInt(e.target.value) || 0) })}
+                        style={{ ...S.baseInput, width: 50, textAlign: 'center' }}
+                        title="WIP limit (0 = unlimited)"
+                      />
+                    </div>
+                    {states.length > 1 && (
+                      <button
+                        onClick={() => removeState(state.id)}
+                        title="Remove state"
+                        style={{ color: S.color.textTertiary, fontSize: 14, border: 'none', background: 'transparent', cursor: 'pointer', padding: '0 4px' }}
+                      >
+                        {'\u00D7'}
+                      </button>
+                    )}
+                  </div>
+
+                  {/* Automatic toggle */}
+                  <label style={{ display: 'flex', alignItems: 'center', gap: 6, cursor: 'pointer' }}>
+                    <input
+                      type="checkbox"
+                      checked={state.isAutomatic}
+                      onChange={(e) => updateState(state.id, { isAutomatic: e.target.checked })}
+                    />
+                    <span style={{ fontSize: 11, color: S.color.textSecondary }}>Automatic</span>
+                  </label>
+
+                  {/* Automation prompts */}
+                  {state.isAutomatic && (
+                    <>
+                      <div>
+                        <label style={{ display: 'block', fontSize: 10, color: S.color.textSecondary, marginBottom: 4 }}>
+                          Execution Prompt
+                        </label>
+                        <textarea
+                          rows={2}
+                          value={state.automationPrompt}
+                          onChange={(e) => updateState(state.id, { automationPrompt: e.target.value })}
+                          placeholder="Describe the work the agent should complete..."
+                          style={{ ...S.baseInput, fontFamily: S.font.mono, fontSize: 11, resize: 'vertical' }}
+                        />
+                      </div>
+                      <div>
+                        <label style={{ display: 'block', fontSize: 10, color: S.color.textSecondary, marginBottom: 4 }}>
+                          Evaluation Prompt <span style={{ color: S.color.textTertiary }}>(optional — defaults to execution prompt)</span>
+                        </label>
+                        <textarea
+                          rows={2}
+                          value={state.evaluationPrompt}
+                          onChange={(e) => updateState(state.id, { evaluationPrompt: e.target.value })}
+                          placeholder="Describe the criteria for evaluating success..."
+                          style={{ ...S.baseInput, fontFamily: S.font.mono, fontSize: 11, resize: 'vertical' }}
+                        />
+                      </div>
+                    </>
+                  )}
+                </div>
+              ))}
+              <button
+                onClick={addState}
+                style={{
+                  width: '100%',
+                  padding: '8px 0',
+                  fontSize: 12,
+                  color: S.color.textTertiary,
+                  border: `1px dashed ${S.color.border}`,
+                  borderRadius: 10,
+                  background: 'transparent',
+                  cursor: 'pointer',
+                  fontFamily: S.font.family,
+                }}
+              >
+                + Add State
+              </button>
+            </div>
+          )}
+
+          {/* ── Swimlanes tab ───────────────────────────────────────────── */}
+          {tab === 'swimlanes' && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+              {swimlanes.map((lane, laneIdx) => (
+                <div
+                  key={lane.id}
+                  draggable
+                  onDragStart={(e) => e.dataTransfer.setData('kanboss/lane-idx', String(laneIdx))}
+                  onDragOver={(e) => e.preventDefault()}
+                  onDrop={(e) => {
+                    e.preventDefault();
+                    const from = e.dataTransfer.getData('kanboss/lane-idx');
+                    if (from !== '') moveSwimlane(parseInt(from), laneIdx);
+                  }}
+                  style={{
+                    padding: 12,
+                    background: S.color.bgSecondary,
+                    border: `1px solid ${S.color.border}`,
+                    borderRadius: 10,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 8,
+                  }}
+                >
+                  {/* Name row */}
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                    <span style={{ color: S.color.textTertiary, cursor: 'grab', fontSize: 12, userSelect: 'none' }} title="Drag to reorder">{'\u2261'}</span>
+                    <input
+                      type="text"
+                      value={lane.name}
+                      onChange={(e) => updateSwimlane(lane.id, { name: e.target.value })}
+                      style={{ ...S.baseInput, flex: 1 }}
+                    />
+                    {swimlanes.length > 1 && (
+                      <button
+                        onClick={() => removeSwimlane(lane.id)}
+                        title="Remove swimlane"
+                        style={{ color: S.color.textTertiary, fontSize: 14, border: 'none', background: 'transparent', cursor: 'pointer', padding: '0 4px' }}
+                      >
+                        {'\u00D7'}
+                      </button>
+                    )}
+                  </div>
+
+                  {/* Agent assignment */}
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                    <div>
+                      <label style={{ display: 'block', fontSize: 10, color: S.color.textSecondary, marginBottom: 4 }}>Manager Agent</label>
+                      <select
+                        value={lane.managerAgentId ?? ''}
+                        onChange={(e) => updateSwimlane(lane.id, { managerAgentId: e.target.value || null })}
+                        style={S.baseInput}
+                      >
+                        <option value="">None (manual only)</option>
+                        {durableAgents.map((agent) => (
+                          <option key={agent.id} value={agent.id}>{agent.name}</option>
+                        ))}
+                      </select>
+                    </div>
+                    <div>
+                      <label style={{ display: 'block', fontSize: 10, color: S.color.textSecondary, marginBottom: 4 }}>Evaluation Agent</label>
+                      <select
+                        value={lane.evaluationAgentId ?? ''}
+                        onChange={(e) => updateSwimlane(lane.id, { evaluationAgentId: e.target.value || null })}
+                        style={S.baseInput}
+                      >
+                        <option value="">Same as manager</option>
+                        {durableAgents.map((agent) => (
+                          <option key={agent.id} value={agent.id}>{agent.name}</option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
+                </div>
+              ))}
+              <button
+                onClick={addSwimlane}
+                style={{
+                  width: '100%',
+                  padding: '8px 0',
+                  fontSize: 12,
+                  color: S.color.textTertiary,
+                  border: `1px dashed ${S.color.border}`,
+                  borderRadius: 10,
+                  background: 'transparent',
+                  cursor: 'pointer',
+                  fontFamily: S.font.family,
+                }}
+              >
+                + Add Swimlane
+              </button>
+            </div>
+          )}
+
+          {/* ── Labels tab ──────────────────────────────────────────────── */}
+          {tab === 'labels' && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+              {labels.length === 0 && (
+                <div style={{ fontSize: 12, color: S.color.textTertiary, textAlign: 'center', padding: 16 }}>
+                  No labels yet. Add labels to categorize your cards.
+                </div>
+              )}
+              {labels.map((label) => (
+                <div
+                  key={label.id}
+                  style={{
+                    padding: 12,
+                    background: S.color.bgSecondary,
+                    border: `1px solid ${S.color.border}`,
+                    borderRadius: 10,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 10,
+                  }}
+                >
+                  {/* Color picker */}
+                  <div style={{ display: 'flex', gap: 4, flexShrink: 0 }}>
+                    {LABEL_COLORS.map((c) => (
+                      <button
+                        key={c}
+                        onClick={() => updateLabel(label.id, { color: c })}
+                        style={{
+                          width: 18,
+                          height: 18,
+                          borderRadius: '50%',
+                          background: c,
+                          border: label.color === c ? '2px solid #fff' : '2px solid transparent',
+                          cursor: 'pointer',
+                          padding: 0,
+                        }}
+                      />
+                    ))}
+                  </div>
+                  {/* Name */}
+                  <input
+                    type="text"
+                    value={label.name}
+                    onChange={(e) => updateLabel(label.id, { name: e.target.value })}
+                    style={{ ...S.baseInput, flex: 1 }}
+                  />
+                  {/* Preview */}
+                  <span style={{
+                    fontSize: 10,
+                    padding: '2px 8px',
+                    borderRadius: 99,
+                    background: `${label.color}20`,
+                    color: label.color,
+                    fontWeight: 500,
+                    whiteSpace: 'nowrap',
+                    flexShrink: 0,
+                  }}>
+                    {label.name || 'Preview'}
+                  </span>
+                  {/* Remove */}
+                  <button
+                    onClick={() => removeLabel(label.id)}
+                    title="Remove label"
+                    style={{ color: S.color.textTertiary, fontSize: 14, border: 'none', background: 'transparent', cursor: 'pointer', padding: '0 4px' }}
+                  >
+                    {'\u00D7'}
+                  </button>
+                </div>
+              ))}
+              <button
+                onClick={addLabel}
+                style={{
+                  width: '100%',
+                  padding: '8px 0',
+                  fontSize: 12,
+                  color: S.color.textTertiary,
+                  border: `1px dashed ${S.color.border}`,
+                  borderRadius: 10,
+                  background: 'transparent',
+                  cursor: 'pointer',
+                  fontFamily: S.font.family,
+                }}
+              >
+                + Add Label
+              </button>
+            </div>
+          )}
+
+          {/* ── Settings tab ────────────────────────────────────────────── */}
+          {tab === 'settings' && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+              <div>
+                <label style={{ display: 'block', fontSize: 12, color: S.color.textSecondary, marginBottom: 4 }}>Max Retries</label>
+                <input
+                  type="number"
+                  min={1}
+                  max={10}
+                  value={maxRetries}
+                  onChange={(e) => setMaxRetries(Math.max(1, Math.min(10, parseInt(e.target.value) || 3)))}
+                  style={{ ...S.baseInput, width: 80, textAlign: 'center' }}
+                />
+                <p style={{ fontSize: 10, color: S.color.textTertiary, marginTop: 4 }}>
+                  Number of times automation will retry before marking a card as stuck.
+                </p>
+              </div>
+
+              <div style={{
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: 10,
+                padding: 10,
+                borderRadius: 10,
+                background: S.color.bgSecondary,
+                border: `1px solid ${S.color.border}`,
+              }}>
+                <input
+                  type="checkbox"
+                  id="cfg-git-history"
+                  checked={gitHistory}
+                  onChange={(e) => setGitHistory(e.target.checked)}
+                  style={{ marginTop: 2 }}
+                />
+                <label htmlFor="cfg-git-history" style={{ cursor: 'pointer', userSelect: 'none' }}>
+                  <div style={{ fontSize: 12, color: S.color.text }}>Enable git history</div>
+                  <p style={{ fontSize: 10, color: S.color.textTertiary, marginTop: 2, lineHeight: 1.5 }}>
+                    Store board data in a git-tracked location so it can be shared with your team.
+                  </p>
+                </label>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'flex-end',
+          gap: 8,
+          padding: '12px 16px',
+          borderTop: `1px solid ${S.color.border}`,
+          fontFamily: S.font.family,
+        }}>
+          <button onClick={handleCancel} style={S.baseButton}>Cancel</button>
+          <button onClick={handleSave} style={S.accentButton}>Save</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/plugins/kanboss/src/BoardSidebar.tsx
+++ b/plugins/kanboss/src/BoardSidebar.tsx
@@ -1,0 +1,354 @@
+const React = globalThis.React;
+const { useEffect, useState, useCallback, useRef } = React;
+
+import type { PluginAPI } from '@clubhouse/plugin-types';
+import type { Board } from './types';
+import { BOARDS_KEY, cardsKey, generateId } from './types';
+import { kanBossState } from './state';
+import * as S from './styles';
+
+// ── Default board factory ───────────────────────────────────────────────
+
+function createDefaultBoard(name: string, gitHistory: boolean): Board {
+  const now = Date.now();
+  return {
+    id: generateId('board'),
+    name,
+    states: [
+      { id: generateId('state'), name: 'Todo',        order: 0, isAutomatic: false, automationPrompt: '', evaluationPrompt: '', wipLimit: 0 },
+      { id: generateId('state'), name: 'In Progress', order: 1, isAutomatic: false, automationPrompt: '', evaluationPrompt: '', wipLimit: 0 },
+      { id: generateId('state'), name: 'Done',        order: 2, isAutomatic: false, automationPrompt: '', evaluationPrompt: '', wipLimit: 0 },
+    ],
+    swimlanes: [
+      { id: generateId('lane'), name: 'Default', order: 0, managerAgentId: null, evaluationAgentId: null },
+    ],
+    labels: [],
+    config: { maxRetries: 3, zoomLevel: 1.0, gitHistory },
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+// ── Create Board Dialog ─────────────────────────────────────────────────
+
+function CreateBoardDialog({ onSave, onCancel }: {
+  onSave: (name: string, gitHistory: boolean) => void;
+  onCancel: () => void;
+}) {
+  const [name, setName] = useState('');
+  const [gitHistory, setGitHistory] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    setTimeout(() => inputRef.current?.focus(), 50);
+  }, []);
+
+  const handleSubmit = useCallback(() => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    onSave(trimmed, gitHistory);
+  }, [name, gitHistory, onSave]);
+
+  return (
+    <div style={S.overlay} onClick={onCancel}>
+      <div style={{ ...S.dialog, maxWidth: 380 }} onClick={(e) => e.stopPropagation()}>
+        {/* Header */}
+        <div style={{ padding: '16px 20px 8px', fontFamily: S.font.family }}>
+          <h2 style={{ fontSize: 14, fontWeight: 600, color: S.color.text, margin: 0 }}>Create Board</h2>
+          <p style={{ fontSize: 11, color: S.color.textTertiary, marginTop: 4 }}>
+            Set up a new Kanban board for your project.
+          </p>
+        </div>
+
+        {/* Form */}
+        <div style={{ padding: '12px 20px', display: 'flex', flexDirection: 'column', gap: 12, fontFamily: S.font.family }}>
+          <div>
+            <label style={{ display: 'block', fontSize: 11, fontWeight: 500, color: S.color.textSecondary, marginBottom: 4 }}>
+              Board Name
+            </label>
+            <input
+              ref={inputRef}
+              type="text"
+              placeholder="e.g. Sprint 14, Feature Work, Bug Triage..."
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') handleSubmit(); }}
+              style={S.baseInput}
+            />
+          </div>
+
+          <div style={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: 10,
+            padding: 10,
+            borderRadius: 10,
+            background: S.color.bgSecondary,
+            border: `1px solid ${S.color.border}`,
+          }}>
+            <input
+              type="checkbox"
+              id="create-git-history"
+              checked={gitHistory}
+              onChange={(e) => setGitHistory(e.target.checked)}
+              style={{ marginTop: 2 }}
+            />
+            <label htmlFor="create-git-history" style={{ cursor: 'pointer', userSelect: 'none' }}>
+              <div style={{ fontSize: 11, fontWeight: 500, color: S.color.text }}>Enable git history</div>
+              <div style={{ fontSize: 10, color: S.color.textTertiary, marginTop: 2, lineHeight: 1.5 }}>
+                Store board data in a git-tracked location so it can be shared with your team.
+              </div>
+            </label>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'flex-end',
+          gap: 8,
+          padding: '12px 20px',
+          borderTop: `1px solid ${S.color.border}`,
+          fontFamily: S.font.family,
+        }}>
+          <button onClick={onCancel} style={S.baseButton}>Cancel</button>
+          <button
+            onClick={handleSubmit}
+            disabled={!name.trim()}
+            style={{ ...S.accentButton, opacity: name.trim() ? 1 : 0.4 }}
+          >
+            Create
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── BoardSidebar (SidebarPanel) ─────────────────────────────────────────
+
+export function BoardSidebar({ api }: { api: PluginAPI }) {
+  const boardsStorage = api.storage.projectLocal;
+  const [boards, setBoards] = useState<Board[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [cardCounts, setCardCounts] = useState<Map<string, number>>(new Map());
+  const [loaded, setLoaded] = useState(false);
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
+
+  const loadBoards = useCallback(async () => {
+    const raw = await boardsStorage.read(BOARDS_KEY);
+    const list: Board[] = Array.isArray(raw) ? raw : [];
+    setBoards(list);
+    kanBossState.setBoards(list);
+
+    const counts = new Map<string, number>();
+    for (const board of list) {
+      const cardsStor = board.config.gitHistory ? api.storage.project : api.storage.projectLocal;
+      const cardsRaw = await cardsStor.read(cardsKey(board.id));
+      const cards = Array.isArray(cardsRaw) ? cardsRaw : [];
+      counts.set(board.id, cards.length);
+    }
+    setCardCounts(counts);
+    if (!loaded) setLoaded(true);
+  }, [boardsStorage, api, loaded]);
+
+  useEffect(() => {
+    loadBoards();
+  }, [loadBoards]);
+
+  useEffect(() => {
+    const unsub = kanBossState.subscribe(() => {
+      setSelectedId(kanBossState.selectedBoardId);
+    });
+    return unsub;
+  }, []);
+
+  const refreshRef = useRef(kanBossState.refreshCount);
+  useEffect(() => {
+    const unsub = kanBossState.subscribe(() => {
+      if (kanBossState.refreshCount !== refreshRef.current) {
+        refreshRef.current = kanBossState.refreshCount;
+        loadBoards();
+      }
+    });
+    return unsub;
+  }, [loadBoards]);
+
+  const handleCreate = useCallback(async (name: string, gitHistory: boolean) => {
+    const board = createDefaultBoard(name, gitHistory);
+    const next = [...boards, board];
+    await boardsStorage.write(BOARDS_KEY, next);
+    const cardsStor = gitHistory ? api.storage.project : api.storage.projectLocal;
+    await cardsStor.write(cardsKey(board.id), []);
+    setBoards(next);
+    kanBossState.setBoards(next);
+    kanBossState.selectBoard(board.id);
+    setSelectedId(board.id);
+    setCardCounts((prev) => new Map(prev).set(board.id, 0));
+    setShowCreateDialog(false);
+  }, [boards, boardsStorage, api]);
+
+  const handleDelete = useCallback(async (boardId: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    const board = boards.find((b) => b.id === boardId);
+    if (!board) return;
+    const ok = await api.ui.showConfirm(`Delete board "${board.name}" and all its cards? This cannot be undone.`);
+    if (!ok) return;
+
+    const next = boards.filter((b) => b.id !== boardId);
+    await boardsStorage.write(BOARDS_KEY, next);
+    const cardsStor = board.config.gitHistory ? api.storage.project : api.storage.projectLocal;
+    await cardsStor.delete(cardsKey(boardId));
+    setBoards(next);
+    kanBossState.setBoards(next);
+
+    if (selectedId === boardId) {
+      const newSel = next.length > 0 ? next[0].id : null;
+      kanBossState.selectBoard(newSel);
+      setSelectedId(newSel);
+    }
+  }, [api, boards, boardsStorage, selectedId]);
+
+  const handleReorder = useCallback(async (fromIdx: number, toIdx: number) => {
+    if (fromIdx === toIdx) return;
+    const result = [...boards];
+    const [moved] = result.splice(fromIdx, 1);
+    result.splice(toIdx, 0, moved);
+    setBoards(result);
+    kanBossState.setBoards(result);
+    await boardsStorage.write(BOARDS_KEY, result);
+  }, [boards, boardsStorage]);
+
+  const handleSelect = useCallback((boardId: string) => {
+    kanBossState.selectBoard(boardId);
+    setSelectedId(boardId);
+  }, []);
+
+  if (!loaded) {
+    return (
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100%',
+        color: S.color.textTertiary,
+        fontSize: 12,
+        fontFamily: S.font.family,
+      }}>
+        Loading...
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', background: S.color.bgSecondary, fontFamily: S.font.family }}>
+      {/* Header */}
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: '8px 12px',
+        borderBottom: `1px solid ${S.color.border}`,
+      }}>
+        <span style={{ fontSize: 12, fontWeight: 500, color: S.color.text }}>Boards</span>
+        <button
+          onClick={() => setShowCreateDialog(true)}
+          title="Create new board"
+          style={{
+            padding: '2px 8px',
+            fontSize: 12,
+            color: S.color.textTertiary,
+            border: 'none',
+            background: 'transparent',
+            cursor: 'pointer',
+            borderRadius: 6,
+          }}
+        >
+          + New
+        </button>
+      </div>
+
+      {/* Board list */}
+      <div style={{ flex: 1, overflowY: 'auto' }}>
+        {boards.length === 0 ? (
+          <div style={{ padding: '16px 12px', fontSize: 12, color: S.color.textTertiary, textAlign: 'center' }}>
+            No boards yet
+          </div>
+        ) : (
+          <div style={{ padding: '2px 0' }}>
+            {boards.map((board, boardIdx) => (
+              <div
+                key={board.id}
+                draggable
+                onDragStart={(e) => e.dataTransfer.setData('kanboss/board-idx', String(boardIdx))}
+                onDragOver={(e) => e.preventDefault()}
+                onDrop={(e) => {
+                  e.preventDefault();
+                  const from = e.dataTransfer.getData('kanboss/board-idx');
+                  if (from !== '') handleReorder(parseInt(from), boardIdx);
+                }}
+                onClick={() => handleSelect(board.id)}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  padding: '10px 12px',
+                  cursor: 'pointer',
+                  transition: 'background 0.15s',
+                  background: board.id === selectedId ? S.color.bgActive : 'transparent',
+                  color: board.id === selectedId ? S.color.text : S.color.textSecondary,
+                }}
+              >
+                <span style={{ color: S.color.textTertiary, fontSize: 10, userSelect: 'none', cursor: 'grab', flexShrink: 0 }}>
+                  {'\u2261'}
+                </span>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 12, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {board.name}
+                  </div>
+                </div>
+                <span style={{
+                  fontSize: 10,
+                  padding: '1px 6px',
+                  borderRadius: 6,
+                  background: S.color.bgTertiary,
+                  color: S.color.textTertiary,
+                  flexShrink: 0,
+                }}>
+                  {cardCounts.get(board.id) ?? 0}
+                </span>
+                <button
+                  onClick={(e) => handleDelete(board.id, e)}
+                  title="Delete board"
+                  style={{
+                    color: S.color.textTertiary,
+                    fontSize: 14,
+                    opacity: board.id === selectedId ? 0.5 : 0,
+                    transition: 'opacity 0.15s',
+                    border: 'none',
+                    background: 'transparent',
+                    cursor: 'pointer',
+                    padding: 0,
+                    flexShrink: 0,
+                  }}
+                  onMouseEnter={(e) => { (e.target as HTMLElement).style.opacity = '1'; }}
+                  onMouseLeave={(e) => { (e.target as HTMLElement).style.opacity = board.id === selectedId ? '0.5' : '0'; }}
+                >
+                  {'\u00D7'}
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {showCreateDialog && (
+        <CreateBoardDialog
+          onSave={handleCreate}
+          onCancel={() => setShowCreateDialog(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/plugins/kanboss/src/BoardView.tsx
+++ b/plugins/kanboss/src/BoardView.tsx
@@ -1,0 +1,498 @@
+const React = globalThis.React;
+const { useEffect, useState, useCallback, useRef } = React;
+
+import type { PluginAPI } from '@clubhouse/plugin-types';
+import type { Board, Card } from './types';
+import { BOARDS_KEY, cardsKey, isCardStuck } from './types';
+import { kanBossState, type FilterState } from './state';
+import { CardCell } from './CardCell';
+import { CardDialog } from './CardDialog';
+import { BoardConfigDialog } from './BoardConfigDialog';
+import { FilterBar } from './FilterBar';
+import { triggerAutomation } from './AutomationEngine';
+import * as S from './styles';
+
+function cardsStorage(api: PluginAPI, board: Board) {
+  return board.config.gitHistory ? api.storage.project : api.storage.projectLocal;
+}
+
+function applyFilter(cards: Card[], filter: FilterState): Card[] {
+  let result = cards;
+
+  if (filter.searchQuery) {
+    const q = filter.searchQuery.toLowerCase();
+    result = result.filter((c) => c.title.toLowerCase().includes(q) || c.body.toLowerCase().includes(q));
+  }
+
+  if (filter.priorityFilter !== 'all') {
+    result = result.filter((c) => c.priority === filter.priorityFilter);
+  }
+
+  if (filter.labelFilter !== 'all') {
+    result = result.filter((c) => c.labels.includes(filter.labelFilter));
+  }
+
+  if (filter.stuckOnly) {
+    result = result.filter(isCardStuck);
+  }
+
+  return result;
+}
+
+// ── Inline keyframes for automation pulse ────────────────────────────────
+
+const PULSE_STYLE = `
+@keyframes kanboss-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.7; }
+}
+`;
+
+export function BoardView({ api }: { api: PluginAPI }) {
+  const boardsStorage = api.storage.projectLocal;
+
+  const [board, setBoard] = useState<Board | null>(null);
+  const [cards, setCards] = useState<Card[]>([]);
+  const [selectedBoardId, setSelectedBoardId] = useState<string | null>(null);
+  const [showCardDialog, setShowCardDialog] = useState(false);
+  const [showConfigDialog, setShowConfigDialog] = useState(false);
+  const [zoomLevel, setZoomLevel] = useState(1.0);
+  const [filter, setFilter] = useState<FilterState>(kanBossState.filter);
+
+  // ── Subscribe to state ────────────────────────────────────────────────
+  useEffect(() => {
+    const unsub = kanBossState.subscribe(() => {
+      setSelectedBoardId(kanBossState.selectedBoardId);
+      setShowCardDialog(kanBossState.editingCardId !== null);
+      setShowConfigDialog(kanBossState.configuringBoard);
+      setFilter({ ...kanBossState.filter });
+    });
+    setSelectedBoardId(kanBossState.selectedBoardId);
+    return unsub;
+  }, []);
+
+  // ── Load board + cards ────────────────────────────────────────────────
+  const loadBoard = useCallback(async () => {
+    if (!selectedBoardId) {
+      setBoard(null);
+      setCards([]);
+      return;
+    }
+    const raw = await boardsStorage.read(BOARDS_KEY);
+    const boards: Board[] = Array.isArray(raw) ? raw : [];
+    const found = boards.find((b) => b.id === selectedBoardId) ?? null;
+    setBoard(found);
+    if (found) {
+      setZoomLevel(found.config.zoomLevel);
+      const cardsStor = cardsStorage(api, found);
+      const cardsRaw = await cardsStor.read(cardsKey(found.id));
+      setCards(Array.isArray(cardsRaw) ? cardsRaw : []);
+    } else {
+      setCards([]);
+    }
+  }, [selectedBoardId, boardsStorage, api]);
+
+  useEffect(() => {
+    loadBoard();
+  }, [loadBoard]);
+
+  const refreshRef = useRef(kanBossState.refreshCount);
+  useEffect(() => {
+    const unsub = kanBossState.subscribe(() => {
+      if (kanBossState.refreshCount !== refreshRef.current) {
+        refreshRef.current = kanBossState.refreshCount;
+        loadBoard();
+      }
+    });
+    return unsub;
+  }, [loadBoard]);
+
+  // ── Zoom controls ─────────────────────────────────────────────────────
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const zoomRef = useRef(zoomLevel);
+  zoomRef.current = zoomLevel;
+
+  const adjustZoom = useCallback(async (delta: number) => {
+    if (!board) return;
+    const newZoom = Math.max(0.5, Math.min(2.0, Math.round((zoomLevel + delta) * 20) / 20));
+    setZoomLevel(newZoom);
+
+    const raw = await boardsStorage.read(BOARDS_KEY);
+    const boards: Board[] = Array.isArray(raw) ? raw : [];
+    const idx = boards.findIndex((b) => b.id === board.id);
+    if (idx !== -1) {
+      boards[idx].config.zoomLevel = newZoom;
+      await boardsStorage.write(BOARDS_KEY, boards);
+    }
+  }, [board, zoomLevel, boardsStorage]);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent) => {
+      if (!e.ctrlKey) return;
+      e.preventDefault();
+      const delta = e.deltaY > 0 ? -0.05 : 0.05;
+      const cur = zoomRef.current;
+      const next = Math.max(0.5, Math.min(2.0, Math.round((cur + delta) * 100) / 100));
+      if (next !== cur) adjustZoom(next - cur);
+    };
+    el.addEventListener('wheel', onWheel, { passive: false });
+    return () => el.removeEventListener('wheel', onWheel);
+  }, [adjustZoom]);
+
+  // ── Move card ─────────────────────────────────────────────────────────
+  const handleMoveCard = useCallback(async (cardId: string, targetStateId: string, targetSwimlaneId?: string) => {
+    if (!board) return;
+
+    const raw = await cardsStorage(api, board).read(cardsKey(board.id));
+    const allCards: Card[] = Array.isArray(raw) ? raw : [];
+    const idx = allCards.findIndex((c) => c.id === cardId);
+    if (idx === -1) return;
+
+    const card = allCards[idx];
+    const stateChanged = card.stateId !== targetStateId;
+    const laneChanged = targetSwimlaneId != null && card.swimlaneId !== targetSwimlaneId;
+
+    if (!stateChanged && !laneChanged) return;
+
+    const fromState = board.states.find((s) => s.id === card.stateId);
+    const toState = board.states.find((s) => s.id === targetStateId);
+    if (!fromState || !toState) return;
+
+    const fromLane = laneChanged ? board.swimlanes.find((l) => l.id === card.swimlaneId) : null;
+    const toLane = laneChanged && targetSwimlaneId ? board.swimlanes.find((l) => l.id === targetSwimlaneId) : null;
+
+    card.stateId = targetStateId;
+    if (targetSwimlaneId) card.swimlaneId = targetSwimlaneId;
+    card.automationAttempts = 0;
+    card.updatedAt = Date.now();
+
+    let detail = '';
+    if (stateChanged) detail = `Moved from "${fromState.name}" to "${toState.name}"`;
+    if (laneChanged && fromLane && toLane) {
+      detail += detail ? `, lane "${fromLane.name}" \u2192 "${toLane.name}"` : `Moved to lane "${toLane.name}"`;
+    }
+
+    card.history.push({ action: 'moved', timestamp: Date.now(), detail });
+
+    allCards[idx] = card;
+    await cardsStorage(api, board).write(cardsKey(board.id), allCards);
+    setCards([...allCards]);
+    kanBossState.triggerRefresh();
+
+    if (stateChanged && toState.isAutomatic) {
+      await triggerAutomation(api, card, board);
+    }
+  }, [board, api]);
+
+  // ── Delete card ───────────────────────────────────────────────────────
+  const handleDeleteCard = useCallback(async (cardId: string) => {
+    if (!board) return;
+    const raw = await cardsStorage(api, board).read(cardsKey(board.id));
+    const allCards: Card[] = Array.isArray(raw) ? raw : [];
+    const filtered = allCards.filter((c) => c.id !== cardId);
+    await cardsStorage(api, board).write(cardsKey(board.id), filtered);
+    setCards(filtered);
+    kanBossState.triggerRefresh();
+  }, [board, api]);
+
+  // ── Clear retries ─────────────────────────────────────────────────────
+  const handleClearRetries = useCallback(async (cardId: string) => {
+    if (!board) return;
+    const raw = await cardsStorage(api, board).read(cardsKey(board.id));
+    const allCards: Card[] = Array.isArray(raw) ? raw : [];
+    const idx = allCards.findIndex((c) => c.id === cardId);
+    if (idx === -1) return;
+
+    allCards[idx].automationAttempts = 0;
+    allCards[idx].updatedAt = Date.now();
+    allCards[idx].history.push({
+      action: 'edited',
+      timestamp: Date.now(),
+      detail: 'Retries cleared \u2014 automation can retry',
+    });
+
+    await cardsStorage(api, board).write(cardsKey(board.id), allCards);
+    setCards([...allCards]);
+    kanBossState.triggerRefresh();
+
+    const state = board.states.find((s) => s.id === allCards[idx].stateId);
+    if (state?.isAutomatic) {
+      await triggerAutomation(api, allCards[idx], board);
+    }
+  }, [board, api]);
+
+  // ── Manual advance ────────────────────────────────────────────────────
+  const handleManualAdvance = useCallback(async (cardId: string) => {
+    if (!board) return;
+    const raw = await cardsStorage(api, board).read(cardsKey(board.id));
+    const allCards: Card[] = Array.isArray(raw) ? raw : [];
+    const idx = allCards.findIndex((c) => c.id === cardId);
+    if (idx === -1) return;
+
+    const card = allCards[idx];
+    const sortedStates = [...board.states].sort((a, b) => a.order - b.order);
+    const curIdx = sortedStates.findIndex((s) => s.id === card.stateId);
+    if (curIdx === -1 || curIdx >= sortedStates.length - 1) return;
+
+    const nextState = sortedStates[curIdx + 1];
+    const fromState = sortedStates[curIdx];
+
+    card.stateId = nextState.id;
+    card.automationAttempts = 0;
+    card.updatedAt = Date.now();
+    card.history.push({
+      action: 'moved',
+      timestamp: Date.now(),
+      detail: `Manually advanced from "${fromState.name}" to "${nextState.name}"`,
+    });
+
+    allCards[idx] = card;
+    await cardsStorage(api, board).write(cardsKey(board.id), allCards);
+    setCards([...allCards]);
+    kanBossState.triggerRefresh();
+  }, [board, api]);
+
+  // ── No board selected ─────────────────────────────────────────────────
+  if (!board) {
+    return (
+      <div style={{
+        flex: 1,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: S.color.textTertiary,
+        fontSize: 12,
+        height: '100%',
+        fontFamily: S.font.family,
+      }}>
+        Select a board to get started
+      </div>
+    );
+  }
+
+  const filteredCards = applyFilter(cards, filter);
+  const sortedStates = [...board.states].sort((a, b) => a.order - b.order);
+  const sortedLanes = [...board.swimlanes].sort((a, b) => a.order - b.order);
+  const lastStateId = sortedStates.length > 0 ? sortedStates[sortedStates.length - 1].id : null;
+  const gridCols = `140px repeat(${sortedStates.length}, minmax(220px, 1fr))`;
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%', background: S.color.bg, fontFamily: S.font.family }}>
+      {/* Inject keyframe animation */}
+      <style dangerouslySetInnerHTML={{ __html: PULSE_STYLE }} />
+
+      {/* Toolbar */}
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '8px 16px',
+        borderBottom: `1px solid ${S.color.border}`,
+        background: S.color.bgSecondary,
+        flexShrink: 0,
+      }}>
+        <span style={{ fontSize: 14, fontWeight: 500, color: S.color.text }}>{board.name}</span>
+        <div style={{ flex: 1 }} />
+
+        {/* Zoom controls */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
+          <button
+            onClick={() => adjustZoom(-0.1)}
+            disabled={zoomLevel <= 0.5}
+            style={{
+              padding: '2px 6px',
+              fontSize: 12,
+              color: S.color.textTertiary,
+              background: S.color.bgTertiary,
+              border: 'none',
+              borderRadius: 4,
+              cursor: 'pointer',
+              opacity: zoomLevel <= 0.5 ? 0.3 : 1,
+            }}
+          >
+            -
+          </button>
+          <span style={{ fontSize: 10, color: S.color.textTertiary, width: 40, textAlign: 'center' }}>
+            {Math.round(zoomLevel * 100)}%
+          </span>
+          <button
+            onClick={() => adjustZoom(0.1)}
+            disabled={zoomLevel >= 2.0}
+            style={{
+              padding: '2px 6px',
+              fontSize: 12,
+              color: S.color.textTertiary,
+              background: S.color.bgTertiary,
+              border: 'none',
+              borderRadius: 4,
+              cursor: 'pointer',
+              opacity: zoomLevel >= 2.0 ? 0.3 : 1,
+            }}
+          >
+            +
+          </button>
+        </div>
+
+        {/* Config button */}
+        <button
+          onClick={() => kanBossState.openBoardConfig()}
+          title="Board settings"
+          style={{
+            width: 32,
+            height: 32,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            fontSize: 18,
+            color: S.color.textTertiary,
+            background: 'transparent',
+            border: 'none',
+            borderRadius: 6,
+            cursor: 'pointer',
+          }}
+        >
+          {'\u2699'}
+        </button>
+      </div>
+
+      {/* Filter bar */}
+      <FilterBar filter={filter} labels={board.labels || []} />
+
+      {/* Grid container */}
+      <div ref={scrollRef} style={{ flex: 1, overflow: 'auto' }}>
+        <div style={{
+          transform: `scale(${zoomLevel})`,
+          transformOrigin: 'top left',
+          minWidth: `${140 + sortedStates.length * 220}px`,
+        }}>
+          <div style={{
+            display: 'grid',
+            gridTemplateColumns: gridCols,
+            gap: 1,
+            borderRadius: 12,
+            overflow: 'hidden',
+            background: `${S.color.border}50`,
+          }}>
+            {/* Header row — empty corner */}
+            <div style={{ background: S.color.bgSecondary, padding: 8 }} />
+
+            {/* State headers */}
+            {sortedStates.map((state) => {
+              const colCards = filteredCards.filter((c) => c.stateId === state.id);
+              const overWip = state.wipLimit > 0 && colCards.length > state.wipLimit;
+              return (
+                <div
+                  key={`header-${state.id}`}
+                  style={{
+                    background: S.color.bgSecondary,
+                    padding: 8,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    ...(overWip ? { borderBottom: `2px solid ${S.color.textError}` } : {}),
+                  }}
+                >
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                    <span style={{ fontSize: 12, fontWeight: 500, color: S.color.text }}>{state.name}</span>
+                    {state.isAutomatic && (
+                      <span style={{
+                        fontSize: 9,
+                        padding: '1px 6px',
+                        borderRadius: 99,
+                        background: S.color.accentBg,
+                        color: S.color.accent,
+                        fontWeight: 500,
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 3,
+                      }}>
+                        {'\u2699'} auto
+                      </span>
+                    )}
+                    {state.wipLimit > 0 && (
+                      <span style={{
+                        fontSize: 9,
+                        color: overWip ? S.color.textError : S.color.textTertiary,
+                        fontWeight: overWip ? 600 : 400,
+                      }}>
+                        {colCards.length}/{state.wipLimit}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+
+            {/* Swimlane rows */}
+            {sortedLanes.flatMap((lane, laneIndex) => {
+              const laneAgents = api.agents.list();
+              const managerAgent = lane.managerAgentId
+                ? laneAgents.find((a) => a.id === lane.managerAgentId)
+                : null;
+
+              const evenBg = S.color.bgSecondary;
+              const oddBg = S.color.bg;
+              const laneBg = laneIndex % 2 === 0 ? evenBg : oddBg;
+              const cellBg = laneIndex % 2 === 0 ? S.color.bg : `${S.color.bgSecondary}80`;
+
+              return [
+                // Swimlane label
+                <div
+                  key={`lane-${lane.id}`}
+                  style={{
+                    background: laneBg,
+                    padding: 8,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <span style={{ fontSize: 12, fontWeight: 500, color: S.color.text }}>{lane.name}</span>
+                  {managerAgent && (
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginTop: 4 }}>
+                      <span style={{ fontSize: 9, color: S.color.textTertiary, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        {managerAgent.name}
+                      </span>
+                    </div>
+                  )}
+                </div>,
+
+                // Card cells
+                ...sortedStates.map((state) => {
+                  const cellCards = filteredCards.filter(
+                    (c) => c.stateId === state.id && c.swimlaneId === lane.id,
+                  );
+                  return (
+                    <div
+                      key={`cell-${lane.id}-${state.id}`}
+                      style={{ background: cellBg, display: 'flex', flexDirection: 'column' }}
+                    >
+                      <CardCell
+                        cards={cellCards}
+                        stateId={state.id}
+                        swimlaneId={lane.id}
+                        isLastState={state.id === lastStateId}
+                        allStates={sortedStates}
+                        boardLabels={board.labels || []}
+                        wipLimit={state.wipLimit}
+                        onMoveCard={handleMoveCard}
+                        onDeleteCard={handleDeleteCard}
+                        onClearRetries={handleClearRetries}
+                        onManualAdvance={handleManualAdvance}
+                      />
+                    </div>
+                  );
+                }),
+              ];
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* Dialogs */}
+      {showCardDialog && <CardDialog api={api} boardId={board.id} boardLabels={board.labels || []} />}
+      {showConfigDialog && <BoardConfigDialog api={api} board={board} />}
+    </div>
+  );
+}

--- a/plugins/kanboss/src/CardCell.tsx
+++ b/plugins/kanboss/src/CardCell.tsx
@@ -1,0 +1,588 @@
+const React = globalThis.React;
+const { useState, useCallback, useRef } = React;
+
+import type { Card, BoardState, Label } from './types';
+import { PRIORITY_CONFIG, PRIORITY_RANK, isCardStuck, isCardAutomating } from './types';
+import { kanBossState } from './state';
+import * as S from './styles';
+
+const MAX_VISIBLE = 5;
+
+export interface CardCellProps {
+  cards: Card[];
+  stateId: string;
+  swimlaneId: string;
+  isLastState: boolean;
+  allStates: BoardState[];
+  boardLabels: Label[];
+  wipLimit: number;
+  onMoveCard: (cardId: string, targetStateId: string, targetSwimlaneId?: string) => void;
+  onDeleteCard: (cardId: string) => void;
+  onClearRetries: (cardId: string) => void;
+  onManualAdvance: (cardId: string) => void;
+}
+
+// ── Move dropdown ───────────────────────────────────────────────────────
+
+function MoveButton({ card, allStates, onMove }: {
+  card: Card;
+  allStates: BoardState[];
+  onMove: (cardId: string, targetStateId: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const otherStates = allStates.filter((s) => s.id !== card.stateId);
+
+  return (
+    <div style={{ position: 'relative', zIndex: open ? 50 : 1 }}>
+      <button
+        onClick={(e) => { e.stopPropagation(); setOpen(!open); }}
+        title="Move card"
+        style={{
+          fontSize: 10,
+          color: S.color.textTertiary,
+          padding: '0 4px',
+          borderRadius: 6,
+          border: 'none',
+          background: 'transparent',
+          cursor: 'pointer',
+        }}
+      >
+        {'\u2192'}
+      </button>
+      {open && (
+        <div style={{
+          position: 'absolute',
+          right: 0,
+          top: 20,
+          background: S.color.bgSecondary,
+          border: `1px solid ${S.color.border}`,
+          borderRadius: 10,
+          boxShadow: '0 10px 25px rgba(0,0,0,0.3)',
+          padding: '4px 0',
+          minWidth: 120,
+          zIndex: 50,
+        }}>
+          {otherStates.map((state) => (
+            <button
+              key={state.id}
+              onClick={(e) => { e.stopPropagation(); onMove(card.id, state.id); setOpen(false); }}
+              style={{
+                display: 'block',
+                width: '100%',
+                textAlign: 'left',
+                padding: '5px 10px',
+                fontSize: 11,
+                color: S.color.text,
+                border: 'none',
+                background: 'transparent',
+                cursor: 'pointer',
+                fontFamily: S.font.family,
+              }}
+            >
+              {state.name}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Card tile ───────────────────────────────────────────────────────────
+
+function CardTile({ card, allStates, boardLabels, onMoveCard, onDeleteCard, onClearRetries, onManualAdvance }: {
+  card: Card;
+  allStates: BoardState[];
+  boardLabels: Label[];
+  onMoveCard: (cardId: string, targetStateId: string) => void;
+  onDeleteCard: (cardId: string) => void;
+  onClearRetries: (cardId: string) => void;
+  onManualAdvance: (cardId: string) => void;
+}) {
+  const stuck = isCardStuck(card);
+  const automating = !stuck && isCardAutomating(card);
+  const hasRetries = !stuck && !automating && card.automationAttempts > 0;
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
+  const config = PRIORITY_CONFIG[card.priority];
+
+  const cardLabels = card.labels
+    .map((lid) => boardLabels.find((l) => l.id === lid))
+    .filter(Boolean) as Label[];
+
+  return (
+    <div
+      draggable
+      onDragStart={(e) => {
+        e.dataTransfer.setData('application/x-kanboss-card', card.id);
+        e.dataTransfer.effectAllowed = 'move';
+      }}
+      onClick={() => kanBossState.openEditCard(card.id)}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+        setContextMenu({ x: e.clientX - rect.left, y: e.clientY - rect.top });
+      }}
+      style={{
+        position: 'relative',
+        background: S.color.bgSecondary,
+        border: `1px solid ${stuck ? S.color.textError : automating ? S.color.accent : S.color.border}`,
+        borderRadius: 10,
+        padding: '8px 10px',
+        cursor: 'grab',
+        transition: 'border-color 0.2s, box-shadow 0.2s',
+        boxShadow: stuck
+          ? `0 0 8px rgba(248, 113, 113, 0.3)`
+          : automating
+          ? `0 0 8px rgba(139, 92, 246, 0.3)`
+          : '0 1px 3px rgba(0,0,0,0.15)',
+        fontFamily: S.font.family,
+        ...(automating ? {
+          animation: 'kanboss-pulse 2s ease-in-out infinite',
+        } : {}),
+      }}
+    >
+      {/* Priority + Labels row */}
+      {(!config.hidden || cardLabels.length > 0) && (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginBottom: 6 }}>
+          {!config.hidden && (
+            <span style={{
+              fontSize: 10,
+              padding: '1px 8px',
+              borderRadius: 99,
+              fontWeight: 500,
+              background: `${config.color}20`,
+              color: config.color,
+            }}>
+              {config.label}
+            </span>
+          )}
+          {cardLabels.map((label) => (
+            <span key={label.id} style={{
+              fontSize: 10,
+              padding: '1px 8px',
+              borderRadius: 99,
+              fontWeight: 500,
+              background: `${label.color}20`,
+              color: label.color,
+            }}>
+              {label.name}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Title + move button */}
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 4 }}>
+        <span style={{
+          flex: 1,
+          minWidth: 0,
+          fontSize: 11,
+          color: S.color.text,
+          fontWeight: 500,
+          lineHeight: 1.4,
+        }}>
+          {card.title}
+        </span>
+        <MoveButton card={card} allStates={allStates} onMove={onMoveCard} />
+      </div>
+
+      {/* Body preview */}
+      {card.body && (
+        <div style={{
+          fontSize: 10,
+          color: S.color.textTertiary,
+          marginTop: 4,
+          lineHeight: 1.5,
+          overflow: 'hidden',
+          display: '-webkit-box',
+          WebkitLineClamp: 2,
+          WebkitBoxOrient: 'vertical' as never,
+        }}>
+          {card.body}
+        </div>
+      )}
+
+      {/* Automation progress indicator */}
+      {automating && (
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 6,
+          marginTop: 6,
+          paddingTop: 6,
+          borderTop: `1px solid ${S.color.border}`,
+        }}>
+          <span style={{
+            fontSize: 9,
+            padding: '2px 8px',
+            borderRadius: 99,
+            background: S.color.accentBg,
+            color: S.color.accent,
+            fontWeight: 600,
+          }}>
+            {'\u2699'} Automating...
+          </span>
+          <span style={{ fontSize: 9, color: S.color.textTertiary }}>
+            Attempt {card.automationAttempts}
+          </span>
+        </div>
+      )}
+
+      {/* Stuck actions */}
+      {stuck && (
+        <div
+          onClick={(e) => e.stopPropagation()}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 6,
+            marginTop: 6,
+            paddingTop: 6,
+            borderTop: `1px solid ${S.color.border}`,
+          }}
+        >
+          <button
+            onClick={(e) => { e.stopPropagation(); onClearRetries(card.id); }}
+            title="Reset retry counter so automation can try again"
+            style={{
+              fontSize: 9,
+              padding: '2px 8px',
+              borderRadius: 99,
+              background: S.color.bgTertiary,
+              color: S.color.textSecondary,
+              border: 'none',
+              cursor: 'pointer',
+            }}
+          >
+            Clear Retries
+          </button>
+          <button
+            onClick={(e) => { e.stopPropagation(); onManualAdvance(card.id); }}
+            title="Manually advance to next state"
+            style={{
+              fontSize: 9,
+              padding: '2px 8px',
+              borderRadius: 99,
+              background: 'rgba(34, 197, 94, 0.15)',
+              color: S.color.textSuccess,
+              border: 'none',
+              cursor: 'pointer',
+            }}
+          >
+            Advance {'\u2192'}
+          </button>
+        </div>
+      )}
+
+      {/* Status badges — top-right corner */}
+      {stuck && (
+        <div style={{
+          position: 'absolute',
+          top: -6,
+          right: -6,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 2,
+          padding: '2px 8px',
+          borderRadius: 99,
+          fontSize: 8,
+          fontWeight: 700,
+          color: '#fff',
+          background: S.color.textError,
+        }}>
+          {'!'} Stuck
+        </div>
+      )}
+      {hasRetries && card.automationAttempts === 1 && (
+        <div style={{
+          position: 'absolute',
+          top: -6,
+          right: -6,
+          padding: '2px 8px',
+          borderRadius: 99,
+          fontSize: 8,
+          fontWeight: 700,
+          color: '#fff',
+          background: S.color.textSuccess,
+        }}>
+          1st Attempt
+        </div>
+      )}
+      {hasRetries && card.automationAttempts > 1 && (
+        <div style={{
+          position: 'absolute',
+          top: -6,
+          right: -6,
+          padding: '2px 8px',
+          borderRadius: 99,
+          fontSize: 8,
+          fontWeight: 700,
+          color: '#fff',
+          background: '#eab308',
+        }}>
+          Retry: {card.automationAttempts - 1}
+        </div>
+      )}
+
+      {/* Context menu */}
+      {contextMenu && (
+        <>
+          <div
+            onClick={(e) => { e.stopPropagation(); setContextMenu(null); }}
+            onContextMenu={(e) => { e.preventDefault(); e.stopPropagation(); setContextMenu(null); }}
+            style={{ position: 'fixed', inset: 0, zIndex: 40 }}
+          />
+          <div
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              position: 'absolute',
+              left: contextMenu.x,
+              top: contextMenu.y,
+              background: S.color.bgSecondary,
+              border: `1px solid ${S.color.border}`,
+              borderRadius: 10,
+              boxShadow: '0 10px 25px rgba(0,0,0,0.3)',
+              padding: '4px 0',
+              zIndex: 50,
+              minWidth: 130,
+            }}
+          >
+            <button
+              onClick={(e) => { e.stopPropagation(); kanBossState.openEditCard(card.id); setContextMenu(null); }}
+              style={{
+                display: 'block',
+                width: '100%',
+                textAlign: 'left',
+                padding: '6px 12px',
+                fontSize: 11,
+                color: S.color.text,
+                border: 'none',
+                background: 'transparent',
+                cursor: 'pointer',
+                fontFamily: S.font.family,
+              }}
+            >
+              Edit
+            </button>
+            <button
+              onClick={(e) => { e.stopPropagation(); onDeleteCard(card.id); setContextMenu(null); }}
+              style={{
+                display: 'block',
+                width: '100%',
+                textAlign: 'left',
+                padding: '6px 12px',
+                fontSize: 11,
+                color: S.color.textError,
+                border: 'none',
+                background: 'transparent',
+                cursor: 'pointer',
+                fontFamily: S.font.family,
+              }}
+            >
+              Delete
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ── CardCell ────────────────────────────────────────────────────────────
+
+export function CardCell({ cards, stateId, swimlaneId, isLastState, allStates, boardLabels, wipLimit, onMoveCard, onDeleteCard, onClearRetries, onManualAdvance }: CardCellProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [isDragOver, setIsDragOver] = useState(false);
+  const dragCounter = useRef(0);
+
+  // Sort cards by priority (critical first, none last)
+  const sorted = [...cards].sort((a, b) => (PRIORITY_RANK[a.priority] ?? 4) - (PRIORITY_RANK[b.priority] ?? 4));
+
+  const overWip = wipLimit > 0 && sorted.length > wipLimit;
+  const atWip = wipLimit > 0 && sorted.length === wipLimit;
+
+  const handleAdd = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    kanBossState.openNewCard(stateId, swimlaneId);
+  }, [stateId, swimlaneId]);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+  }, []);
+
+  const handleDragEnter = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    dragCounter.current++;
+    if (dragCounter.current === 1) setIsDragOver(true);
+  }, []);
+
+  const handleDragLeave = useCallback(() => {
+    dragCounter.current--;
+    if (dragCounter.current === 0) setIsDragOver(false);
+  }, []);
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    dragCounter.current = 0;
+    setIsDragOver(false);
+    const cardId = e.dataTransfer.getData('application/x-kanboss-card');
+    if (cardId) onMoveCard(cardId, stateId, swimlaneId);
+  }, [onMoveCard, stateId, swimlaneId]);
+
+  const dropProps = {
+    onDragOver: handleDragOver,
+    onDragEnter: handleDragEnter,
+    onDragLeave: handleDragLeave,
+    onDrop: handleDrop,
+  };
+
+  // Last state: collapse to "N done" badge by default
+  if (isLastState && sorted.length > 0 && !expanded) {
+    return (
+      <div
+        {...dropProps}
+        style={{
+          flex: 1,
+          padding: 8,
+          minHeight: 60,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          transition: 'background 0.2s',
+          ...(isDragOver ? {
+            background: 'rgba(59, 130, 246, 0.1)',
+            boxShadow: 'inset 0 0 0 1px rgba(59, 130, 246, 0.3)',
+            borderRadius: 10,
+          } : {}),
+        }}
+      >
+        <button
+          onClick={() => setExpanded(true)}
+          style={{
+            padding: '4px 12px',
+            fontSize: 11,
+            borderRadius: 99,
+            background: 'rgba(34, 197, 94, 0.15)',
+            color: S.color.textSuccess,
+            border: 'none',
+            cursor: 'pointer',
+          }}
+        >
+          {sorted.length} done
+        </button>
+      </div>
+    );
+  }
+
+  // Determine visible cards
+  const visibleCards = expanded || sorted.length <= MAX_VISIBLE ? sorted : sorted.slice(0, MAX_VISIBLE);
+  const hiddenCount = sorted.length - visibleCards.length;
+
+  return (
+    <div
+      {...dropProps}
+      style={{
+        flex: 1,
+        padding: 8,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 6,
+        minHeight: 60,
+        transition: 'background 0.2s',
+        ...(overWip ? { background: 'rgba(248, 113, 113, 0.05)' } : {}),
+        ...(isDragOver ? {
+          background: 'rgba(59, 130, 246, 0.1)',
+          boxShadow: 'inset 0 0 0 1px rgba(59, 130, 246, 0.3)',
+          borderRadius: 10,
+        } : {}),
+      }}
+    >
+      {/* WIP limit indicator */}
+      {wipLimit > 0 && (
+        <div style={{
+          fontSize: 9,
+          color: overWip ? S.color.textError : atWip ? '#eab308' : S.color.textTertiary,
+          textAlign: 'right',
+          fontWeight: overWip ? 600 : 400,
+        }}>
+          {sorted.length}/{wipLimit}
+        </div>
+      )}
+
+      {/* Cards */}
+      {visibleCards.map((card) => (
+        <CardTile
+          key={card.id}
+          card={card}
+          allStates={allStates}
+          boardLabels={boardLabels}
+          onMoveCard={onMoveCard}
+          onDeleteCard={onDeleteCard}
+          onClearRetries={onClearRetries}
+          onManualAdvance={onManualAdvance}
+        />
+      ))}
+
+      {/* "+N more" pill */}
+      {hiddenCount > 0 && (
+        <button
+          onClick={() => setExpanded(true)}
+          style={{
+            width: '100%',
+            textAlign: 'center',
+            fontSize: 10,
+            color: S.color.textTertiary,
+            padding: '2px 0',
+            borderRadius: 8,
+            border: 'none',
+            background: 'transparent',
+            cursor: 'pointer',
+          }}
+        >
+          +{hiddenCount} more
+        </button>
+      )}
+
+      {/* Collapse button for expanded last-state */}
+      {isLastState && expanded && (
+        <button
+          onClick={() => setExpanded(false)}
+          style={{
+            width: '100%',
+            textAlign: 'center',
+            fontSize: 10,
+            color: S.color.textTertiary,
+            padding: '2px 0',
+            borderRadius: 8,
+            border: 'none',
+            background: 'transparent',
+            cursor: 'pointer',
+          }}
+        >
+          Collapse
+        </button>
+      )}
+
+      {/* + Add button */}
+      <button
+        onClick={handleAdd}
+        style={{
+          width: '100%',
+          textAlign: 'center',
+          fontSize: 10,
+          color: S.color.textTertiary,
+          padding: '2px 0',
+          marginTop: 2,
+          borderRadius: 8,
+          border: 'none',
+          background: 'transparent',
+          cursor: 'pointer',
+        }}
+      >
+        + Add
+      </button>
+    </div>
+  );
+}

--- a/plugins/kanboss/src/CardDialog.tsx
+++ b/plugins/kanboss/src/CardDialog.tsx
@@ -1,0 +1,303 @@
+const React = globalThis.React;
+const { useState, useCallback, useEffect } = React;
+
+import type { Card, Priority, HistoryEntry, Label } from './types';
+import { cardsKey, generateId, PRIORITY_CONFIG } from './types';
+import { kanBossState } from './state';
+import * as S from './styles';
+
+const PRIORITIES: Priority[] = ['none', 'low', 'medium', 'high', 'critical'];
+
+interface CardDialogProps {
+  api: import('@clubhouse/plugin-types').PluginAPI;
+  boardId: string;
+  boardLabels: Label[];
+}
+
+// ── History entry display ───────────────────────────────────────────────
+
+function HistoryItem({ entry }: { entry: HistoryEntry }) {
+  const time = new Date(entry.timestamp).toLocaleString(undefined, {
+    month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit',
+  });
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, padding: '4px 0' }}>
+      <span style={{ fontSize: 10, color: S.color.textTertiary, flexShrink: 0, width: 96 }}>{time}</span>
+      <span style={{ fontSize: 10, color: S.color.textSecondary }}>{entry.detail}</span>
+    </div>
+  );
+}
+
+// ── CardDialog ──────────────────────────────────────────────────────────
+
+export function CardDialog({ api, boardId, boardLabels }: CardDialogProps) {
+  const currentBoard = kanBossState.boards.find((b) => b.id === boardId);
+  const storage = currentBoard?.config.gitHistory ? api.storage.project : api.storage.projectLocal;
+  const isNew = kanBossState.editingCardId === 'new';
+  const cardId = isNew ? null : kanBossState.editingCardId;
+
+  const [title, setTitle] = useState('');
+  const [body, setBody] = useState('');
+  const [priority, setPriority] = useState<Priority>('none');
+  const [selectedLabels, setSelectedLabels] = useState<string[]>([]);
+  const [history, setHistory] = useState<HistoryEntry[]>([]);
+  const [loaded, setLoaded] = useState(isNew);
+
+  // Load existing card data
+  useEffect(() => {
+    if (isNew || !cardId) {
+      setTitle('');
+      setBody('');
+      setPriority('none');
+      setSelectedLabels([]);
+      setHistory([]);
+      setLoaded(true);
+      return;
+    }
+    (async () => {
+      const raw = await storage.read(cardsKey(boardId));
+      const cards: Card[] = Array.isArray(raw) ? raw : [];
+      const card = cards.find((c) => c.id === cardId);
+      if (card) {
+        setTitle(card.title);
+        setBody(card.body);
+        setPriority(card.priority);
+        setSelectedLabels(card.labels || []);
+        setHistory(card.history);
+      }
+      setLoaded(true);
+    })();
+  }, [cardId, isNew, boardId, storage]);
+
+  // ── Toggle label ─────────────────────────────────────────────────────
+  const toggleLabel = useCallback((labelId: string) => {
+    setSelectedLabels((prev) =>
+      prev.includes(labelId) ? prev.filter((l) => l !== labelId) : [...prev, labelId]
+    );
+  }, []);
+
+  // ── Save ────────────────────────────────────────────────────────────
+  const handleSave = useCallback(async () => {
+    if (!title.trim()) return;
+
+    const raw = await storage.read(cardsKey(boardId));
+    const cards: Card[] = Array.isArray(raw) ? raw : [];
+    const now = Date.now();
+
+    if (isNew) {
+      const newCard: Card = {
+        id: generateId('card'),
+        boardId,
+        title: title.trim(),
+        body,
+        priority,
+        labels: selectedLabels,
+        stateId: kanBossState.editingStateId!,
+        swimlaneId: kanBossState.editingSwimlaneId!,
+        history: [{ action: 'created', timestamp: now, detail: `Created "${title.trim()}"` }],
+        automationAttempts: 0,
+        createdAt: now,
+        updatedAt: now,
+      };
+      cards.push(newCard);
+    } else if (cardId) {
+      const idx = cards.findIndex((c) => c.id === cardId);
+      if (idx !== -1) {
+        const card = cards[idx];
+        const changes: string[] = [];
+        if (card.title !== title.trim()) changes.push('title');
+        if (card.body !== body) changes.push('body');
+        if (card.priority !== priority) {
+          changes.push('priority');
+          card.history.push({
+            action: 'priority-changed',
+            timestamp: now,
+            detail: `Priority changed from ${card.priority} to ${priority}`,
+          });
+        }
+        if (JSON.stringify(card.labels) !== JSON.stringify(selectedLabels)) changes.push('labels');
+        if (changes.length > 0) {
+          card.history.push({
+            action: 'edited',
+            timestamp: now,
+            detail: `Edited: ${changes.join(', ')}`,
+          });
+        }
+        card.title = title.trim();
+        card.body = body;
+        card.priority = priority;
+        card.labels = selectedLabels;
+        card.updatedAt = now;
+        cards[idx] = card;
+      }
+    }
+
+    await storage.write(cardsKey(boardId), cards);
+    kanBossState.closeCardDialog();
+    kanBossState.triggerRefresh();
+  }, [title, body, priority, selectedLabels, isNew, cardId, boardId, storage]);
+
+  // ── Delete ──────────────────────────────────────────────────────────
+  const handleDelete = useCallback(async () => {
+    if (!cardId) return;
+    const ok = await api.ui.showConfirm('Delete this card? This cannot be undone.');
+    if (!ok) return;
+
+    const raw = await storage.read(cardsKey(boardId));
+    const cards: Card[] = Array.isArray(raw) ? raw : [];
+    const next = cards.filter((c) => c.id !== cardId);
+    await storage.write(cardsKey(boardId), next);
+    kanBossState.closeCardDialog();
+    kanBossState.triggerRefresh();
+  }, [api, cardId, boardId, storage]);
+
+  const handleCancel = useCallback(() => {
+    kanBossState.closeCardDialog();
+  }, []);
+
+  if (!loaded) return null;
+
+  return (
+    <div style={S.overlay} onClick={handleCancel}>
+      <div style={{ ...S.dialog, maxWidth: 520 }} onClick={(e) => e.stopPropagation()}>
+        {/* Header */}
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '12px 16px',
+          borderBottom: `1px solid ${S.color.border}`,
+        }}>
+          <span style={{ fontSize: 14, fontWeight: 500, color: S.color.text, fontFamily: S.font.family }}>
+            {isNew ? 'New Card' : 'Edit Card'}
+          </span>
+          <button
+            onClick={handleCancel}
+            style={{
+              color: S.color.textTertiary,
+              fontSize: 18,
+              border: 'none',
+              background: 'transparent',
+              cursor: 'pointer',
+            }}
+          >
+            {'\u00D7'}
+          </button>
+        </div>
+
+        {/* Form */}
+        <div style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 12, fontFamily: S.font.family }}>
+          {/* Title */}
+          <div>
+            <label style={{ display: 'block', fontSize: 11, color: S.color.textSecondary, marginBottom: 4 }}>Title</label>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Card title..."
+              autoFocus
+              style={S.baseInput}
+            />
+          </div>
+
+          {/* Body */}
+          <div>
+            <label style={{ display: 'block', fontSize: 11, color: S.color.textSecondary, marginBottom: 4 }}>Description</label>
+            <textarea
+              rows={4}
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              placeholder="Description..."
+              style={{ ...S.baseInput, resize: 'vertical' }}
+            />
+          </div>
+
+          {/* Priority */}
+          <div>
+            <label style={{ display: 'block', fontSize: 11, color: S.color.textSecondary, marginBottom: 4 }}>Priority</label>
+            <select
+              value={priority}
+              onChange={(e) => setPriority(e.target.value as Priority)}
+              style={S.baseInput}
+            >
+              {PRIORITIES.map((p) => (
+                <option key={p} value={p}>{PRIORITY_CONFIG[p].label}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* Labels */}
+          {boardLabels.length > 0 && (
+            <div>
+              <label style={{ display: 'block', fontSize: 11, color: S.color.textSecondary, marginBottom: 6 }}>Labels</label>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+                {boardLabels.map((label) => {
+                  const isSelected = selectedLabels.includes(label.id);
+                  return (
+                    <button
+                      key={label.id}
+                      onClick={() => toggleLabel(label.id)}
+                      style={{
+                        fontSize: 11,
+                        padding: '3px 10px',
+                        borderRadius: 99,
+                        border: `1px solid ${isSelected ? label.color : S.color.border}`,
+                        background: isSelected ? `${label.color}20` : 'transparent',
+                        color: isSelected ? label.color : S.color.textSecondary,
+                        cursor: 'pointer',
+                        fontWeight: isSelected ? 500 : 400,
+                        fontFamily: S.font.family,
+                      }}
+                    >
+                      {label.name}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* History (edit mode only) */}
+        {!isNew && history.length > 0 && (
+          <div style={{ padding: '0 16px 12px' }}>
+            <div style={{ fontSize: 12, fontWeight: 500, color: S.color.textSecondary, marginBottom: 6, fontFamily: S.font.family }}>History</div>
+            <div style={{
+              maxHeight: 128,
+              overflowY: 'auto',
+              border: `1px solid ${S.color.border}`,
+              borderRadius: 8,
+              padding: 8,
+              background: S.color.bgSecondary,
+            }}>
+              {[...history].reverse().map((entry, i) => (
+                <HistoryItem key={i} entry={entry} />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Footer */}
+        <div style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '12px 16px',
+          borderTop: `1px solid ${S.color.border}`,
+          fontFamily: S.font.family,
+        }}>
+          {!isNew ? (
+            <button onClick={handleDelete} style={S.dangerButton}>Delete</button>
+          ) : (
+            <div />
+          )}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <button onClick={handleCancel} style={S.baseButton}>Cancel</button>
+            <button onClick={handleSave} style={S.accentButton}>Save</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/plugins/kanboss/src/FilterBar.tsx
+++ b/plugins/kanboss/src/FilterBar.tsx
@@ -1,0 +1,123 @@
+const React = globalThis.React;
+const { useCallback } = React;
+
+import type { Label, Priority } from './types';
+import { PRIORITY_CONFIG } from './types';
+import { kanBossState, type FilterState } from './state';
+import * as S from './styles';
+
+interface FilterBarProps {
+  filter: FilterState;
+  labels: Label[];
+}
+
+const PRIORITIES: Priority[] = ['none', 'low', 'medium', 'high', 'critical'];
+
+export function FilterBar({ filter, labels }: FilterBarProps) {
+  const hasFilters = filter.searchQuery || filter.priorityFilter !== 'all' || filter.labelFilter !== 'all' || filter.stuckOnly;
+
+  const handleSearch = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    kanBossState.setFilter({ searchQuery: e.target.value });
+  }, []);
+
+  const handlePriority = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    kanBossState.setFilter({ priorityFilter: e.target.value as Priority | 'all' });
+  }, []);
+
+  const handleLabel = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
+    kanBossState.setFilter({ labelFilter: e.target.value });
+  }, []);
+
+  const handleStuck = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    kanBossState.setFilter({ stuckOnly: e.target.checked });
+  }, []);
+
+  return (
+    <div style={{
+      display: 'flex',
+      alignItems: 'center',
+      gap: 8,
+      padding: '6px 16px',
+      borderBottom: `1px solid ${S.color.border}`,
+      background: S.color.bgSecondary,
+      flexShrink: 0,
+      fontFamily: S.font.family,
+      fontSize: 11,
+    }}>
+      {/* Search */}
+      <input
+        type="text"
+        placeholder="Search cards..."
+        value={filter.searchQuery}
+        onChange={handleSearch}
+        style={{
+          ...S.baseInput,
+          width: 160,
+          padding: '4px 8px',
+          fontSize: 11,
+        }}
+      />
+
+      {/* Priority filter */}
+      <select
+        value={filter.priorityFilter}
+        onChange={handlePriority}
+        style={{
+          ...S.baseInput,
+          width: 'auto',
+          padding: '4px 8px',
+          fontSize: 11,
+        }}
+      >
+        <option value="all">All priorities</option>
+        {PRIORITIES.map((p) => (
+          <option key={p} value={p}>{PRIORITY_CONFIG[p].label}</option>
+        ))}
+      </select>
+
+      {/* Label filter */}
+      {labels.length > 0 && (
+        <select
+          value={filter.labelFilter}
+          onChange={handleLabel}
+          style={{
+            ...S.baseInput,
+            width: 'auto',
+            padding: '4px 8px',
+            fontSize: 11,
+          }}
+        >
+          <option value="all">All labels</option>
+          {labels.map((l) => (
+            <option key={l.id} value={l.id}>{l.name}</option>
+          ))}
+        </select>
+      )}
+
+      {/* Stuck only */}
+      <label style={{ display: 'flex', alignItems: 'center', gap: 4, color: S.color.textSecondary, cursor: 'pointer', whiteSpace: 'nowrap' }}>
+        <input
+          type="checkbox"
+          checked={filter.stuckOnly}
+          onChange={handleStuck}
+        />
+        Stuck only
+      </label>
+
+      {/* Clear */}
+      {hasFilters && (
+        <button
+          onClick={() => kanBossState.clearFilter()}
+          style={{
+            ...S.baseButton,
+            padding: '3px 8px',
+            fontSize: 10,
+            color: S.color.textTertiary,
+          }}
+        >
+          Clear
+        </button>
+      )}
+    </div>
+  );
+}

--- a/plugins/kanboss/src/main.tsx
+++ b/plugins/kanboss/src/main.tsx
@@ -1,0 +1,47 @@
+const React = globalThis.React;
+
+import type { PluginContext, PluginAPI, PanelProps } from '@clubhouse/plugin-types';
+import { kanBossState } from './state';
+import { BoardSidebar } from './BoardSidebar';
+import { BoardView } from './BoardView';
+import { initAutomationEngine, shutdownAutomationEngine } from './AutomationEngine';
+
+// ── activate() ──────────────────────────────────────────────────────────
+
+export function activate(ctx: PluginContext, api: PluginAPI): void {
+  api.logging.info('KanBoss plugin activated');
+
+  // Register commands
+  const refreshCmd = api.commands.register('refresh', () => {
+    kanBossState.triggerRefresh();
+  });
+  ctx.subscriptions.push(refreshCmd);
+
+  const newBoardCmd = api.commands.register('new-board', async () => {
+    const name = await api.ui.showInput('Board name', 'New Board');
+    if (!name) return;
+    kanBossState.triggerRefresh();
+  });
+  ctx.subscriptions.push(newBoardCmd);
+
+  // Initialize automation engine
+  const automationSub = initAutomationEngine(api);
+  ctx.subscriptions.push(automationSub);
+}
+
+// ── deactivate() ────────────────────────────────────────────────────────
+
+export function deactivate(): void {
+  shutdownAutomationEngine();
+  kanBossState.reset();
+}
+
+// ── Panels ──────────────────────────────────────────────────────────────
+
+export function SidebarPanel({ api }: PanelProps) {
+  return <BoardSidebar api={api} />;
+}
+
+export function MainPanel({ api }: PanelProps) {
+  return <BoardView api={api} />;
+}

--- a/plugins/kanboss/src/manifest.test.ts
+++ b/plugins/kanboss/src/manifest.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import manifest from '../manifest.json';
+
+describe('KanBoss manifest', () => {
+  it('has correct plugin id', () => {
+    expect(manifest.id).toBe('kanboss');
+  });
+
+  it('has correct scope', () => {
+    expect(manifest.scope).toBe('project');
+  });
+
+  it('targets API version 0.5', () => {
+    expect(manifest.engine.api).toBe(0.5);
+  });
+
+  it('declares required permissions', () => {
+    expect(manifest.permissions).toContain('storage');
+    expect(manifest.permissions).toContain('agents');
+    expect(manifest.permissions).toContain('commands');
+    expect(manifest.permissions).toContain('notifications');
+    expect(manifest.permissions).toContain('logging');
+  });
+
+  it('contributes a tab with sidebar-content layout', () => {
+    expect(manifest.contributes.tab).toBeDefined();
+    expect(manifest.contributes.tab.label).toBe('KanBoss');
+    expect(manifest.contributes.tab.layout).toBe('sidebar-content');
+  });
+
+  it('has icon SVG', () => {
+    expect(manifest.contributes.tab.icon).toContain('<svg');
+  });
+
+  it('contributes commands', () => {
+    const ids = manifest.contributes.commands.map((c: { id: string }) => c.id);
+    expect(ids).toContain('refresh');
+    expect(ids).toContain('new-board');
+  });
+
+  it('contributes help topics', () => {
+    expect(manifest.contributes.help.topics.length).toBeGreaterThanOrEqual(1);
+    const ids = manifest.contributes.help.topics.map((t: { id: string }) => t.id);
+    expect(ids).toContain('kanboss');
+    expect(ids).toContain('kanboss-automation');
+  });
+});

--- a/plugins/kanboss/src/state.test.ts
+++ b/plugins/kanboss/src/state.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { kanBossState } from './state';
+
+describe('kanBossState', () => {
+  beforeEach(() => {
+    kanBossState.reset();
+  });
+
+  it('starts with null selectedBoardId', () => {
+    expect(kanBossState.selectedBoardId).toBeNull();
+  });
+
+  it('selectBoard sets id and closes dialogs', () => {
+    kanBossState.editingCardId = 'some-card';
+    kanBossState.configuringBoard = true;
+
+    kanBossState.selectBoard('board-1');
+
+    expect(kanBossState.selectedBoardId).toBe('board-1');
+    expect(kanBossState.editingCardId).toBeNull();
+    expect(kanBossState.configuringBoard).toBe(false);
+  });
+
+  it('setBoards updates boards array', () => {
+    const boards = [{ id: 'b1', name: 'Test' } as any];
+    kanBossState.setBoards(boards);
+    expect(kanBossState.boards).toEqual(boards);
+  });
+
+  it('openNewCard sets editing state', () => {
+    kanBossState.openNewCard('state-1', 'lane-1');
+    expect(kanBossState.editingCardId).toBe('new');
+    expect(kanBossState.editingStateId).toBe('state-1');
+    expect(kanBossState.editingSwimlaneId).toBe('lane-1');
+  });
+
+  it('openEditCard sets editing card id', () => {
+    kanBossState.openEditCard('card-123');
+    expect(kanBossState.editingCardId).toBe('card-123');
+    expect(kanBossState.editingStateId).toBeNull();
+    expect(kanBossState.editingSwimlaneId).toBeNull();
+  });
+
+  it('closeCardDialog clears all editing state', () => {
+    kanBossState.openNewCard('state-1', 'lane-1');
+    kanBossState.closeCardDialog();
+
+    expect(kanBossState.editingCardId).toBeNull();
+    expect(kanBossState.editingStateId).toBeNull();
+    expect(kanBossState.editingSwimlaneId).toBeNull();
+  });
+
+  it('openBoardConfig and closeBoardConfig toggle configuringBoard', () => {
+    kanBossState.openBoardConfig();
+    expect(kanBossState.configuringBoard).toBe(true);
+
+    kanBossState.closeBoardConfig();
+    expect(kanBossState.configuringBoard).toBe(false);
+  });
+
+  it('triggerRefresh increments refreshCount', () => {
+    expect(kanBossState.refreshCount).toBe(0);
+    kanBossState.triggerRefresh();
+    expect(kanBossState.refreshCount).toBe(1);
+    kanBossState.triggerRefresh();
+    expect(kanBossState.refreshCount).toBe(2);
+  });
+
+  it('subscribe notifies listeners on changes', () => {
+    let callCount = 0;
+    kanBossState.subscribe(() => { callCount++; });
+
+    kanBossState.triggerRefresh();
+    expect(callCount).toBe(1);
+
+    kanBossState.selectBoard('b1');
+    expect(callCount).toBe(2);
+  });
+
+  it('unsubscribe stops notifications', () => {
+    let callCount = 0;
+    const unsub = kanBossState.subscribe(() => { callCount++; });
+
+    kanBossState.triggerRefresh();
+    expect(callCount).toBe(1);
+
+    unsub();
+    kanBossState.triggerRefresh();
+    expect(callCount).toBe(1);
+  });
+
+  it('setFilter updates filter state', () => {
+    kanBossState.setFilter({ searchQuery: 'test', stuckOnly: true });
+    expect(kanBossState.filter.searchQuery).toBe('test');
+    expect(kanBossState.filter.stuckOnly).toBe(true);
+    expect(kanBossState.filter.priorityFilter).toBe('all');
+  });
+
+  it('clearFilter resets all filters', () => {
+    kanBossState.setFilter({ searchQuery: 'test', stuckOnly: true, priorityFilter: 'high' });
+    kanBossState.clearFilter();
+
+    expect(kanBossState.filter.searchQuery).toBe('');
+    expect(kanBossState.filter.stuckOnly).toBe(false);
+    expect(kanBossState.filter.priorityFilter).toBe('all');
+    expect(kanBossState.filter.labelFilter).toBe('all');
+  });
+
+  it('reset clears everything', () => {
+    kanBossState.selectBoard('b1');
+    kanBossState.triggerRefresh();
+    kanBossState.setFilter({ searchQuery: 'hello' });
+
+    kanBossState.reset();
+
+    expect(kanBossState.selectedBoardId).toBeNull();
+    expect(kanBossState.refreshCount).toBe(0);
+    expect(kanBossState.filter.searchQuery).toBe('');
+    expect(kanBossState.listeners.size).toBe(0);
+  });
+});

--- a/plugins/kanboss/src/state.ts
+++ b/plugins/kanboss/src/state.ts
@@ -1,0 +1,121 @@
+/**
+ * Shared module-level state for the KanBoss plugin.
+ *
+ * SidebarPanel and MainPanel are rendered in separate React trees,
+ * so we use a lightweight pub/sub to coordinate the selected board
+ * and dialog visibility.
+ */
+
+import type { Board, Priority } from './types';
+
+export interface FilterState {
+  searchQuery: string;
+  priorityFilter: Priority | 'all';
+  labelFilter: string | 'all'; // label ID or 'all'
+  stuckOnly: boolean;
+}
+
+export const kanBossState = {
+  selectedBoardId: null as string | null,
+  boards: [] as Board[],
+  refreshCount: 0,
+
+  // Dialog state
+  editingCardId: null as string | null,   // null=closed, 'new'=creating, cardId=editing
+  editingStateId: null as string | null,  // target state for new card
+  editingSwimlaneId: null as string | null, // target swimlane for new card
+  configuringBoard: false,
+
+  // Filter state
+  filter: {
+    searchQuery: '',
+    priorityFilter: 'all',
+    labelFilter: 'all',
+    stuckOnly: false,
+  } as FilterState,
+
+  listeners: new Set<() => void>(),
+
+  selectBoard(id: string | null): void {
+    this.selectedBoardId = id;
+    this.editingCardId = null;
+    this.configuringBoard = false;
+    this.notify();
+  },
+
+  setBoards(boards: Board[]): void {
+    this.boards = boards;
+    this.notify();
+  },
+
+  openNewCard(stateId: string, swimlaneId: string): void {
+    this.editingCardId = 'new';
+    this.editingStateId = stateId;
+    this.editingSwimlaneId = swimlaneId;
+    this.notify();
+  },
+
+  openEditCard(cardId: string): void {
+    this.editingCardId = cardId;
+    this.editingStateId = null;
+    this.editingSwimlaneId = null;
+    this.notify();
+  },
+
+  closeCardDialog(): void {
+    this.editingCardId = null;
+    this.editingStateId = null;
+    this.editingSwimlaneId = null;
+    this.notify();
+  },
+
+  openBoardConfig(): void {
+    this.configuringBoard = true;
+    this.notify();
+  },
+
+  closeBoardConfig(): void {
+    this.configuringBoard = false;
+    this.notify();
+  },
+
+  setFilter(updates: Partial<FilterState>): void {
+    this.filter = { ...this.filter, ...updates };
+    this.notify();
+  },
+
+  clearFilter(): void {
+    this.filter = { searchQuery: '', priorityFilter: 'all', labelFilter: 'all', stuckOnly: false };
+    this.notify();
+  },
+
+  triggerRefresh(): void {
+    this.refreshCount++;
+    this.notify();
+  },
+
+  subscribe(fn: () => void): () => void {
+    this.listeners.add(fn);
+    return () => {
+      this.listeners.delete(fn);
+    };
+  },
+
+  notify(): void {
+    for (const fn of this.listeners) {
+      fn();
+    }
+  },
+
+  reset(): void {
+    this.selectedBoardId = null;
+    this.boards = [];
+    this.refreshCount = 0;
+    this.editingCardId = null;
+    this.editingStateId = null;
+    this.editingSwimlaneId = null;
+    this.configuringBoard = false;
+    this.filter = { searchQuery: '', priorityFilter: 'all', labelFilter: 'all', stuckOnly: false };
+    this.listeners.clear();
+  },
+};

--- a/plugins/kanboss/src/styles.ts
+++ b/plugins/kanboss/src/styles.ts
@@ -1,0 +1,95 @@
+/**
+ * Shared style constants using CSS custom properties for theming.
+ * All colors adapt to the host app's theme.
+ */
+
+export const font = {
+  family: 'var(--font-family, system-ui, -apple-system, sans-serif)',
+  mono: 'var(--font-mono, ui-monospace, monospace)',
+};
+
+export const color = {
+  text: 'var(--text-primary, #e4e4e7)',
+  textSecondary: 'var(--text-secondary, #a1a1aa)',
+  textTertiary: 'var(--text-tertiary, #71717a)',
+  textError: 'var(--text-error, #f87171)',
+  textSuccess: '#22c55e',
+  textAccent: 'var(--text-accent, #8b5cf6)',
+
+  bg: 'var(--bg-primary, #18181b)',
+  bgSecondary: 'var(--bg-secondary, #27272a)',
+  bgTertiary: 'var(--bg-tertiary, #333338)',
+  bgActive: 'var(--bg-active, #3f3f46)',
+  bgError: 'var(--bg-error, #2a1515)',
+
+  border: 'var(--border-primary, #3f3f46)',
+  borderSecondary: 'var(--border-secondary, #52525b)',
+  accent: 'var(--text-accent, #8b5cf6)',
+  accentBg: 'var(--bg-accent, rgba(139, 92, 246, 0.15))',
+};
+
+// Common style patterns
+export const baseInput: React.CSSProperties = {
+  width: '100%',
+  padding: '6px 10px',
+  fontSize: 12,
+  borderRadius: 8,
+  background: color.bgSecondary,
+  border: `1px solid ${color.border}`,
+  color: color.text,
+  outline: 'none',
+  fontFamily: font.family,
+};
+
+export const baseButton: React.CSSProperties = {
+  padding: '5px 12px',
+  fontSize: 12,
+  borderRadius: 8,
+  border: `1px solid ${color.border}`,
+  background: 'transparent',
+  color: color.textSecondary,
+  cursor: 'pointer',
+  fontFamily: font.family,
+};
+
+export const accentButton: React.CSSProperties = {
+  ...baseButton,
+  background: color.accent,
+  border: 'none',
+  color: '#fff',
+  fontWeight: 500,
+};
+
+export const dangerButton: React.CSSProperties = {
+  ...baseButton,
+  color: color.textError,
+  borderColor: 'rgba(248, 113, 113, 0.3)',
+};
+
+export const overlay: React.CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(0, 0, 0, 0.5)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 50,
+};
+
+export const dialog: React.CSSProperties = {
+  background: color.bg,
+  border: `1px solid ${color.border}`,
+  borderRadius: 12,
+  boxShadow: '0 25px 50px -12px rgba(0, 0, 0, 0.5)',
+  width: '100%',
+  maxWidth: 480,
+  margin: '0 16px',
+};
+
+export const dialogWide: React.CSSProperties = {
+  ...dialog,
+  maxWidth: 640,
+  maxHeight: '80vh',
+  display: 'flex',
+  flexDirection: 'column',
+};

--- a/plugins/kanboss/src/types.test.ts
+++ b/plugins/kanboss/src/types.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { generateId, isCardStuck, isCardAutomating, PRIORITY_CONFIG, PRIORITY_RANK, LABEL_COLORS } from './types';
+import type { Card } from './types';
+
+describe('generateId', () => {
+  it('produces unique IDs with the given prefix', () => {
+    const id1 = generateId('card');
+    const id2 = generateId('card');
+    expect(id1).toMatch(/^card_/);
+    expect(id2).toMatch(/^card_/);
+    expect(id1).not.toBe(id2);
+  });
+
+  it('accepts different prefixes', () => {
+    expect(generateId('board')).toMatch(/^board_/);
+    expect(generateId('state')).toMatch(/^state_/);
+  });
+});
+
+function makeCard(history: Card['history']): Card {
+  return {
+    id: 'c1',
+    boardId: 'b1',
+    title: 'Test',
+    body: '',
+    priority: 'none',
+    labels: [],
+    stateId: 's1',
+    swimlaneId: 'l1',
+    history,
+    automationAttempts: 3,
+    createdAt: 0,
+    updatedAt: 0,
+  };
+}
+
+describe('isCardStuck', () => {
+  it('returns true when last relevant action is automation-stuck', () => {
+    const card = makeCard([
+      { action: 'created', timestamp: 1, detail: '' },
+      { action: 'automation-stuck', timestamp: 2, detail: '' },
+    ]);
+    expect(isCardStuck(card)).toBe(true);
+  });
+
+  it('returns false when card was moved after getting stuck', () => {
+    const card = makeCard([
+      { action: 'automation-stuck', timestamp: 1, detail: '' },
+      { action: 'moved', timestamp: 2, detail: '' },
+    ]);
+    expect(isCardStuck(card)).toBe(false);
+  });
+
+  it('returns false for card with no stuck history', () => {
+    const card = makeCard([{ action: 'created', timestamp: 1, detail: '' }]);
+    expect(isCardStuck(card)).toBe(false);
+  });
+});
+
+describe('isCardAutomating', () => {
+  it('returns true when last relevant action is automation-started', () => {
+    const card = makeCard([
+      { action: 'created', timestamp: 1, detail: '' },
+      { action: 'automation-started', timestamp: 2, detail: '' },
+    ]);
+    expect(isCardAutomating(card)).toBe(true);
+  });
+
+  it('returns false after automation succeeded', () => {
+    const card = makeCard([
+      { action: 'automation-started', timestamp: 1, detail: '' },
+      { action: 'automation-succeeded', timestamp: 2, detail: '' },
+    ]);
+    expect(isCardAutomating(card)).toBe(false);
+  });
+
+  it('returns false after automation failed', () => {
+    const card = makeCard([
+      { action: 'automation-started', timestamp: 1, detail: '' },
+      { action: 'automation-failed', timestamp: 2, detail: '' },
+    ]);
+    expect(isCardAutomating(card)).toBe(false);
+  });
+});
+
+describe('PRIORITY_CONFIG', () => {
+  it('has entries for all priority levels', () => {
+    expect(PRIORITY_CONFIG.none).toBeDefined();
+    expect(PRIORITY_CONFIG.low).toBeDefined();
+    expect(PRIORITY_CONFIG.medium).toBeDefined();
+    expect(PRIORITY_CONFIG.high).toBeDefined();
+    expect(PRIORITY_CONFIG.critical).toBeDefined();
+  });
+
+  it('none is hidden', () => {
+    expect(PRIORITY_CONFIG.none.hidden).toBe(true);
+  });
+});
+
+describe('PRIORITY_RANK', () => {
+  it('ranks critical highest (0) and none lowest (4)', () => {
+    expect(PRIORITY_RANK.critical).toBe(0);
+    expect(PRIORITY_RANK.none).toBe(4);
+  });
+});
+
+describe('LABEL_COLORS', () => {
+  it('provides at least 6 colors', () => {
+    expect(LABEL_COLORS.length).toBeGreaterThanOrEqual(6);
+  });
+});

--- a/plugins/kanboss/src/types.ts
+++ b/plugins/kanboss/src/types.ts
@@ -1,0 +1,150 @@
+// ── KanBoss data models ─────────────────────────────────────────────────
+
+export type Priority = 'none' | 'low' | 'medium' | 'high' | 'critical';
+
+export type HistoryAction =
+  | 'created'
+  | 'moved'
+  | 'edited'
+  | 'priority-changed'
+  | 'automation-started'
+  | 'automation-succeeded'
+  | 'automation-failed'
+  | 'automation-stuck';
+
+export interface HistoryEntry {
+  action: HistoryAction;
+  timestamp: number;
+  detail: string;
+  agentId?: string;
+}
+
+export interface Label {
+  id: string;
+  name: string;
+  color: string;
+}
+
+export interface Card {
+  id: string;
+  boardId: string;
+  title: string;
+  body: string;
+  priority: Priority;
+  labels: string[]; // label IDs
+  stateId: string;
+  swimlaneId: string;
+  history: HistoryEntry[];
+  automationAttempts: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface BoardState {
+  id: string;
+  name: string;
+  order: number;
+  isAutomatic: boolean;
+  automationPrompt: string;
+  evaluationPrompt: string; // separate from execution prompt
+  wipLimit: number; // 0 = unlimited
+}
+
+export interface Swimlane {
+  id: string;
+  name: string;
+  order: number;
+  managerAgentId: string | null;
+  evaluationAgentId: string | null; // null = same as manager agent
+}
+
+export interface BoardConfig {
+  maxRetries: number;
+  zoomLevel: number;
+  gitHistory: boolean;
+}
+
+export interface Board {
+  id: string;
+  name: string;
+  states: BoardState[];
+  swimlanes: Swimlane[];
+  labels: Label[];
+  config: BoardConfig;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface AutomationRun {
+  cardId: string;
+  boardId: string;
+  stateId: string;
+  swimlaneId: string;
+  executionAgentId: string;
+  evaluationAgentId: string | null;
+  configuredEvaluationAgentId: string | null; // from swimlane config; null = same as manager
+  phase: 'executing' | 'evaluating';
+  attempt: number;
+  startedAt: number;
+}
+
+// ── Storage keys ────────────────────────────────────────────────────────
+
+export const BOARDS_KEY = 'boards';
+export const cardsKey = (boardId: string): string => `cards:${boardId}`;
+export const AUTOMATION_RUNS_KEY = 'automation-runs';
+
+// ── Priority display config ─────────────────────────────────────────────
+
+export const PRIORITY_CONFIG: Record<Priority, { label: string; color: string; hidden?: boolean }> = {
+  none:     { label: 'None',     color: '', hidden: true },
+  low:      { label: 'Low',      color: 'var(--text-info, #3b82f6)' },
+  medium:   { label: 'Medium',   color: 'var(--text-warning, #eab308)' },
+  high:     { label: 'High',     color: '#f97316' },
+  critical: { label: 'Critical', color: 'var(--text-error, #ef4444)' },
+};
+
+// Priority sort order: critical first, none last
+export const PRIORITY_RANK: Record<string, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+  none: 4,
+};
+
+// ── Default label colors ────────────────────────────────────────────────
+
+export const LABEL_COLORS = [
+  '#3b82f6', // blue
+  '#22c55e', // green
+  '#f97316', // orange
+  '#ef4444', // red
+  '#a855f7', // purple
+  '#ec4899', // pink
+  '#06b6d4', // cyan
+  '#eab308', // yellow
+];
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+export function generateId(prefix: string): string {
+  return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function isCardStuck(card: Card): boolean {
+  for (let i = card.history.length - 1; i >= 0; i--) {
+    if (card.history[i].action === 'automation-stuck') return true;
+    if (card.history[i].action === 'moved') return false;
+  }
+  return false;
+}
+
+export function isCardAutomating(card: Card): boolean {
+  for (let i = card.history.length - 1; i >= 0; i--) {
+    const a = card.history[i].action;
+    if (a === 'automation-started') return true;
+    if (a === 'automation-succeeded' || a === 'automation-failed' || a === 'automation-stuck' || a === 'moved') return false;
+  }
+  return false;
+}

--- a/plugins/kanboss/tsconfig.json
+++ b/plugins/kanboss/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "declaration": false,
+    "noEmit": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- Migrates the KanBoss kanban board plugin from the main Clubhouse app to the Workshop plugins repo as a standalone external plugin
- Converts all components from `React.createElement` to JSX and replaces Tailwind classes with inline styles using CSS custom properties for proper theme support
- Adds card labels/tags, per-column WIP limits, card search/filter bar, and per-state evaluation prompts (separate from execution prompts)
- Includes visual polish: card shadows, automation progress indicators with pulsing borders, and automatic column badges

## What's New vs. the Builtin
| Feature | Builtin | External |
|---------|---------|----------|
| Rendering | `React.createElement` | JSX (`.tsx`) |
| Theming | Hardcoded hex + Tailwind | CSS custom properties |
| Card labels | - | Colored labels per board |
| WIP limits | - | Per-column limits with visual warnings |
| Search/filter | - | By title, priority, label, stuck |
| Evaluation prompts | Same as execution | Separate per-state |
| Automation UX | Badge only | Pulsing border + phase badge |
| Column indicators | "auto" text | Gear icon + accent styling |

## Test Plan
- [x] All 33 unit tests passing (manifest, state, types)
- [x] TypeScript typecheck passes with zero errors
- [x] esbuild produces 93.9kb bundle
- [ ] Manual: install plugin, create board, add cards with labels
- [ ] Manual: set WIP limits, verify column warnings at/over limit
- [ ] Manual: configure automation with separate eval prompts, verify two-phase flow
- [ ] Manual: test search/filter bar across title, priority, label, stuck

🤖 Generated with [Claude Code](https://claude.com/claude-code)