### PR TITLE
fix: add missing author field to github-issues manifest

### DIFF
--- a/plugins/github-issues/manifest.json
+++ b/plugins/github-issues/manifest.json
@@ -3,6 +3,7 @@
   "name": "GitHub Issue Tracker",
   "version": "0.1.0",
   "description": "Create and manage GitHub issues with template support, label validation, and agent assignment",
+  "author": "Clubhouse Workshop",
   "engine": { "api": 0.5 },
   "scope": "project",
   "main": "./dist/main.js",


### PR DESCRIPTION
## Summary
- Adds the required `author` field to the github-issues plugin manifest
- Needed for the release workflow validation which checks for this field

## Context
Preparing to tag official v0.1.0 releases for both `github-issues` and `kanboss` plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)