### PR TITLE
fix: improve GitHub Issues plugin filter, theming, and rendering

### DIFF
--- a/plugins/github-issues/package.json
+++ b/plugins/github-issues/package.json
@@ -7,12 +7,15 @@
   "scripts": {
     "build": "esbuild src/main.tsx --bundle --format=esm --platform=browser --external:react --outfile=dist/main.js",
     "watch": "esbuild src/main.tsx --bundle --format=esm --platform=browser --external:react --outfile=dist/main.js --watch",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "devDependencies": {
-    "@clubhouse/plugin-types": "file:../../sdk/plugin-types",
+    "@clubhouse/plugin-types": "file:../../sdk/v0.5/plugin-types",
+    "@clubhouse/plugin-testing": "file:../../sdk/v0.5/plugin-testing",
     "@types/react": "^19.0.0",
     "esbuild": "^0.24.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
   }
 }

--- a/plugins/github-issues/src/helpers.test.ts
+++ b/plugins/github-issues/src/helpers.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect } from "vitest";
+import {
+  relativeTime,
+  labelColor,
+  extractYamlValue,
+  filterIssues,
+  parseInlineSegments,
+  classifyLine,
+  IssueListItem,
+} from "./helpers";
+
+// ---------------------------------------------------------------------------
+// relativeTime
+// ---------------------------------------------------------------------------
+
+describe("relativeTime", () => {
+  it("returns 'just now' for recent dates", () => {
+    const now = new Date().toISOString();
+    expect(relativeTime(now)).toBe("just now");
+  });
+
+  it("returns minutes ago", () => {
+    const fiveMinAgo = new Date(Date.now() - 5 * 60000).toISOString();
+    expect(relativeTime(fiveMinAgo)).toBe("5m ago");
+  });
+
+  it("returns hours ago", () => {
+    const threeHoursAgo = new Date(Date.now() - 3 * 3600000).toISOString();
+    expect(relativeTime(threeHoursAgo)).toBe("3h ago");
+  });
+
+  it("returns days ago", () => {
+    const twoDaysAgo = new Date(Date.now() - 2 * 86400000).toISOString();
+    expect(relativeTime(twoDaysAgo)).toBe("2d ago");
+  });
+
+  it("returns months ago", () => {
+    const sixtyDaysAgo = new Date(Date.now() - 60 * 86400000).toISOString();
+    expect(relativeTime(sixtyDaysAgo)).toBe("2mo ago");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// labelColor
+// ---------------------------------------------------------------------------
+
+describe("labelColor", () => {
+  it("returns #888 for empty string", () => {
+    expect(labelColor("")).toBe("#888");
+  });
+
+  it("passes through hex values starting with #", () => {
+    expect(labelColor("#ff0000")).toBe("#ff0000");
+  });
+
+  it("prepends # to raw hex values", () => {
+    expect(labelColor("d73a4a")).toBe("#d73a4a");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractYamlValue
+// ---------------------------------------------------------------------------
+
+describe("extractYamlValue", () => {
+  it("extracts unquoted values", () => {
+    expect(extractYamlValue("name: Bug Report", "name")).toBe("Bug Report");
+  });
+
+  it("extracts quoted values", () => {
+    expect(extractYamlValue("title: 'My Title'", "title")).toBe("My Title");
+  });
+
+  it("returns null for missing keys", () => {
+    expect(extractYamlValue("name: Bug Report", "description")).toBeNull();
+  });
+
+  it("handles multiline yaml", () => {
+    const yaml = "name: Bug Report\ndescription: File a bug\ntitle: '[Bug] '";
+    expect(extractYamlValue(yaml, "description")).toBe("File a bug");
+    expect(extractYamlValue(yaml, "name")).toBe("Bug Report");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterIssues
+// ---------------------------------------------------------------------------
+
+describe("filterIssues", () => {
+  const issues: IssueListItem[] = [
+    {
+      number: 1,
+      title: "Fix login page",
+      state: "open",
+      url: "https://github.com/test/repo/issues/1",
+      createdAt: "2024-01-01T00:00:00Z",
+      updatedAt: "2024-01-01T00:00:00Z",
+      author: { login: "alice" },
+      labels: [{ name: "bug", color: "d73a4a" }],
+    },
+    {
+      number: 2,
+      title: "Add dark mode",
+      state: "open",
+      url: "https://github.com/test/repo/issues/2",
+      createdAt: "2024-01-02T00:00:00Z",
+      updatedAt: "2024-01-02T00:00:00Z",
+      author: { login: "bob" },
+      labels: [{ name: "enhancement", color: "a2eeef" }],
+    },
+    {
+      number: 3,
+      title: "Update README",
+      state: "open",
+      url: "https://github.com/test/repo/issues/3",
+      createdAt: "2024-01-03T00:00:00Z",
+      updatedAt: "2024-01-03T00:00:00Z",
+      author: { login: "charlie" },
+      labels: [
+        { name: "documentation", color: "0075ca" },
+        { name: "good first issue", color: "7057ff" },
+      ],
+    },
+  ];
+
+  it("returns all issues for empty query", () => {
+    expect(filterIssues(issues, "")).toEqual(issues);
+    expect(filterIssues(issues, "  ")).toEqual(issues);
+  });
+
+  it("filters by title", () => {
+    const result = filterIssues(issues, "login");
+    expect(result).toHaveLength(1);
+    expect(result[0].number).toBe(1);
+  });
+
+  it("filters by issue number", () => {
+    const result = filterIssues(issues, "#2");
+    expect(result).toHaveLength(1);
+    expect(result[0].number).toBe(2);
+  });
+
+  it("filters by label name", () => {
+    const result = filterIssues(issues, "bug");
+    expect(result).toHaveLength(1);
+    expect(result[0].number).toBe(1);
+  });
+
+  it("filters by partial label name", () => {
+    const result = filterIssues(issues, "enhance");
+    expect(result).toHaveLength(1);
+    expect(result[0].number).toBe(2);
+  });
+
+  it("is case-insensitive for labels", () => {
+    const result = filterIssues(issues, "BUG");
+    expect(result).toHaveLength(1);
+    expect(result[0].number).toBe(1);
+  });
+
+  it("matches labels with spaces", () => {
+    const result = filterIssues(issues, "good first");
+    expect(result).toHaveLength(1);
+    expect(result[0].number).toBe(3);
+  });
+
+  it("returns empty for no matches", () => {
+    expect(filterIssues(issues, "nonexistent")).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseInlineSegments (markdown inline parsing)
+// ---------------------------------------------------------------------------
+
+describe("parseInlineSegments", () => {
+  it("returns plain text for no formatting", () => {
+    const result = parseInlineSegments("Hello world");
+    expect(result).toEqual([{ type: "text", content: "Hello world" }]);
+  });
+
+  it("parses bold text", () => {
+    const result = parseInlineSegments("Hello **bold** world");
+    expect(result).toEqual([
+      { type: "text", content: "Hello " },
+      { type: "bold", content: "bold" },
+      { type: "text", content: " world" },
+    ]);
+  });
+
+  it("parses italic text", () => {
+    const result = parseInlineSegments("Hello *italic* world");
+    expect(result).toEqual([
+      { type: "text", content: "Hello " },
+      { type: "italic", content: "italic" },
+      { type: "text", content: " world" },
+    ]);
+  });
+
+  it("parses inline code", () => {
+    const result = parseInlineSegments("Use `npm install`");
+    expect(result).toEqual([
+      { type: "text", content: "Use " },
+      { type: "code", content: "npm install" },
+    ]);
+  });
+
+  it("parses links", () => {
+    const result = parseInlineSegments("Visit [GitHub](https://github.com)");
+    expect(result).toEqual([
+      { type: "text", content: "Visit " },
+      { type: "link", content: "GitHub", href: "https://github.com" },
+    ]);
+  });
+
+  it("parses images", () => {
+    const result = parseInlineSegments("![alt text](https://example.com/img.png)");
+    expect(result).toEqual([
+      { type: "image", content: "alt text", href: "https://example.com/img.png" },
+    ]);
+  });
+
+  it("parses strikethrough", () => {
+    const result = parseInlineSegments("This is ~~wrong~~ correct");
+    expect(result).toEqual([
+      { type: "text", content: "This is " },
+      { type: "strikethrough", content: "wrong" },
+      { type: "text", content: " correct" },
+    ]);
+  });
+
+  it("handles mixed inline formatting", () => {
+    const result = parseInlineSegments("**bold** and `code` and *italic*");
+    expect(result).toHaveLength(5);
+    expect(result[0]).toEqual({ type: "bold", content: "bold" });
+    expect(result[2]).toEqual({ type: "code", content: "code" });
+    expect(result[4]).toEqual({ type: "italic", content: "italic" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyLine (markdown block detection)
+// ---------------------------------------------------------------------------
+
+describe("classifyLine", () => {
+  it("detects blank lines", () => {
+    expect(classifyLine("")).toBe("blank");
+    expect(classifyLine("   ")).toBe("blank");
+  });
+
+  it("detects headings", () => {
+    expect(classifyLine("# Heading")).toBe("heading");
+    expect(classifyLine("## Subheading")).toBe("heading");
+    expect(classifyLine("###### H6")).toBe("heading");
+  });
+
+  it("detects code fences", () => {
+    expect(classifyLine("```")).toBe("code-fence");
+    expect(classifyLine("```javascript")).toBe("code-fence");
+  });
+
+  it("detects blockquotes", () => {
+    expect(classifyLine("> quote")).toBe("blockquote");
+    expect(classifyLine(">")).toBe("blockquote");
+  });
+
+  it("detects unordered lists", () => {
+    expect(classifyLine("- item")).toBe("unordered-list");
+    expect(classifyLine("* item")).toBe("unordered-list");
+    expect(classifyLine("+ item")).toBe("unordered-list");
+  });
+
+  it("detects ordered lists", () => {
+    expect(classifyLine("1. item")).toBe("ordered-list");
+    expect(classifyLine("12) item")).toBe("ordered-list");
+  });
+
+  it("detects horizontal rules", () => {
+    expect(classifyLine("---")).toBe("hr");
+    expect(classifyLine("***")).toBe("hr");
+    expect(classifyLine("___")).toBe("hr");
+  });
+
+  it("defaults to paragraph", () => {
+    expect(classifyLine("Regular text")).toBe("paragraph");
+  });
+});

--- a/plugins/github-issues/src/helpers.ts
+++ b/plugins/github-issues/src/helpers.ts
@@ -1,0 +1,100 @@
+// Pure helper functions extracted for testability.
+
+export function relativeTime(dateStr: string): string {
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  const diffMs = now - then;
+  const diffMin = Math.floor(diffMs / 60000);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffH = Math.floor(diffMin / 60);
+  if (diffH < 24) return `${diffH}h ago`;
+  const diffD = Math.floor(diffH / 24);
+  if (diffD < 30) return `${diffD}d ago`;
+  const diffMo = Math.floor(diffD / 30);
+  return `${diffMo}mo ago`;
+}
+
+export function labelColor(hex: string): string {
+  if (!hex) return "#888";
+  return hex.startsWith("#") ? hex : `#${hex}`;
+}
+
+export function extractYamlValue(yaml: string, key: string): string | null {
+  const match = yaml.match(new RegExp(`^${key}:\\s*["']?(.+?)["']?\\s*$`, "m"));
+  return match ? match[1] : null;
+}
+
+export interface IssueListItem {
+  number: number;
+  title: string;
+  state: string;
+  url: string;
+  createdAt: string;
+  updatedAt: string;
+  author: { login: string };
+  labels: Array<{ name: string; color: string }>;
+}
+
+/** Client-side filter: matches title, issue number, and label names. */
+export function filterIssues(issues: IssueListItem[], query: string): IssueListItem[] {
+  if (!query.trim()) return issues;
+  const q = query.toLowerCase();
+  return issues.filter(
+    i =>
+      i.title.toLowerCase().includes(q) ||
+      `#${i.number}`.includes(q) ||
+      i.labels.some(l => l.name.toLowerCase().includes(q)),
+  );
+}
+
+/**
+ * Parse a simple markdown string into text segments for testing.
+ * This mirrors the inline regex from the Markdown component.
+ */
+export function parseInlineSegments(
+  text: string,
+): Array<{ type: "text" | "bold" | "italic" | "code" | "link" | "strikethrough" | "image"; content: string; href?: string }> {
+  const segments: Array<{ type: "text" | "bold" | "italic" | "code" | "link" | "strikethrough" | "image"; content: string; href?: string }> = [];
+  const inlineRe =
+    /!\[([^\]]*)\]\(([^)]+)\)|(\[([^\]]+)\]\(([^)]+)\))|(`[^`]+`)|(\*\*[^*]+\*\*)|(__[^_]+__)|(\*[^*]+\*)|(_[^_]+_)|(~~[^~]+~~)/g;
+  let last = 0;
+  let match: RegExpExecArray | null;
+
+  while ((match = inlineRe.exec(text)) !== null) {
+    if (match.index > last) segments.push({ type: "text", content: text.slice(last, match.index) });
+    const m = match[0];
+
+    if (m.startsWith("![")) {
+      segments.push({ type: "image", content: match[1], href: match[2] });
+    } else if (m.startsWith("[")) {
+      segments.push({ type: "link", content: match[4], href: match[5] });
+    } else if (m.startsWith("`")) {
+      segments.push({ type: "code", content: m.slice(1, -1) });
+    } else if (m.startsWith("**") || m.startsWith("__")) {
+      segments.push({ type: "bold", content: m.slice(2, -2) });
+    } else if (m.startsWith("~~")) {
+      segments.push({ type: "strikethrough", content: m.slice(2, -2) });
+    } else if (m.startsWith("*") || m.startsWith("_")) {
+      segments.push({ type: "italic", content: m.slice(1, -1) });
+    }
+    last = match.index + m.length;
+  }
+
+  if (last < text.length) segments.push({ type: "text", content: text.slice(last) });
+  return segments;
+}
+
+/** Detect block-level markdown elements. */
+export function classifyLine(
+  line: string,
+): "heading" | "code-fence" | "blockquote" | "unordered-list" | "ordered-list" | "hr" | "paragraph" | "blank" {
+  if (!line.trim()) return "blank";
+  if (line.startsWith("```")) return "code-fence";
+  if (/^#{1,6}\s+/.test(line)) return "heading";
+  if (/^[-*_]{3,}\s*$/.test(line)) return "hr";
+  if (line.startsWith("> ") || line === ">") return "blockquote";
+  if (/^\s*[-*+]\s/.test(line)) return "unordered-list";
+  if (/^\s*\d+[.)]\s/.test(line)) return "ordered-list";
+  return "paragraph";
+}

--- a/plugins/github-issues/src/main.tsx
+++ b/plugins/github-issues/src/main.tsx
@@ -4,6 +4,7 @@ import type {
   PanelProps,
   AgentInfo,
 } from "@clubhouse/plugin-types";
+import { relativeTime, labelColor, extractYamlValue } from "./helpers";
 
 const React = globalThis.React;
 const { useState, useEffect, useCallback, useRef, useMemo } = React;
@@ -143,25 +144,7 @@ const issueState = {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function relativeTime(dateStr: string): string {
-  const now = Date.now();
-  const then = new Date(dateStr).getTime();
-  const diffMs = now - then;
-  const diffMin = Math.floor(diffMs / 60000);
-  if (diffMin < 1) return "just now";
-  if (diffMin < 60) return `${diffMin}m ago`;
-  const diffH = Math.floor(diffMin / 60);
-  if (diffH < 24) return `${diffH}h ago`;
-  const diffD = Math.floor(diffH / 24);
-  if (diffD < 30) return `${diffD}d ago`;
-  const diffMo = Math.floor(diffD / 30);
-  return `${diffMo}mo ago`;
-}
-
-function labelColor(hex: string): string {
-  if (!hex) return "#888";
-  return hex.startsWith("#") ? hex : `#${hex}`;
-}
+// relativeTime, labelColor, and extractYamlValue imported from ./helpers
 
 // ---------------------------------------------------------------------------
 // Markdown renderer (lightweight GFM-subset → JSX, no external deps)
@@ -496,10 +479,7 @@ function parseTemplate(content: string, filename: string): IssueTemplate | null 
   };
 }
 
-function extractYamlValue(yaml: string, key: string): string | null {
-  const match = yaml.match(new RegExp(`^${key}:\\s*["']?(.+?)["']?\\s*$`, "m"));
-  return match ? match[1] : null;
-}
+// extractYamlValue imported from ./helpers
 
 // ---------------------------------------------------------------------------
 // Lifecycle

--- a/plugins/github-issues/src/manifest.test.ts
+++ b/plugins/github-issues/src/manifest.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import manifest from "../manifest.json";
+
+describe("github-issues manifest", () => {
+  it("has correct plugin id", () => {
+    expect(manifest.id).toBe("github-issues");
+  });
+
+  it("has correct scope", () => {
+    expect(manifest.scope).toBe("project");
+  });
+
+  it("targets API version 0.5", () => {
+    expect(manifest.engine.api).toBe(0.5);
+  });
+
+  it("declares required permissions", () => {
+    expect(manifest.permissions).toContain("logging");
+    expect(manifest.permissions).toContain("storage");
+    expect(manifest.permissions).toContain("notifications");
+    expect(manifest.permissions).toContain("files");
+    expect(manifest.permissions).toContain("agents");
+    expect(manifest.permissions).toContain("commands");
+    expect(manifest.permissions).toContain("process");
+    expect(manifest.permissions).toContain("settings");
+    expect(manifest.permissions).toContain("widgets");
+  });
+
+  it("contributes a tab with sidebar-content layout", () => {
+    expect(manifest.contributes.tab).toBeDefined();
+    expect(manifest.contributes.tab.label).toBe("Issues");
+    expect(manifest.contributes.tab.layout).toBe("sidebar-content");
+  });
+
+  it("has icon SVG", () => {
+    expect(manifest.contributes.tab.icon).toContain("<svg");
+  });
+
+  it("contributes commands", () => {
+    const ids = manifest.contributes.commands.map((c: { id: string }) => c.id);
+    expect(ids).toContain("github-issues.refresh");
+    expect(ids).toContain("github-issues.create");
+    expect(ids).toContain("github-issues.assignAgent");
+    expect(ids).toContain("github-issues.toggleState");
+    expect(ids).toContain("github-issues.viewInBrowser");
+  });
+
+  it("contributes settings", () => {
+    const keys = manifest.contributes.settings.map((s: { key: string }) => s.key);
+    expect(keys).toContain("defaultRepo");
+  });
+
+  it("contributes help topics", () => {
+    expect(manifest.contributes.help.topics.length).toBeGreaterThanOrEqual(1);
+    const ids = manifest.contributes.help.topics.map((t: { id: string }) => t.id);
+    expect(ids).toContain("github-issues");
+  });
+
+  it("only allows gh command", () => {
+    expect(manifest.allowedCommands).toEqual(["gh"]);
+  });
+});


### PR DESCRIPTION
## Summary

- **Filter improvements**: Search now matches against issue label names (not just title and number), so typing "bug" finds issues with a "bug" label. Removed unicode ellipsis character from the filter placeholder.
- **Theme alignment**: Updated all CSS custom property names to match the host app's theme system (`--bg-primary`, `--bg-secondary`, `--text-primary`, `--border-primary`, `--text-accent`, etc.) and updated fallback values and font stacks to match the established conventions used by other plugins (e.g., KanBoss).
- **Markdown rendering**: Replaced monospace `<pre>` rendering of issue bodies and comments with a lightweight GFM-subset markdown-to-JSX renderer. Supports headings, bold, italic, strikethrough, inline code, fenced code blocks, links, images, ordered/unordered lists, task lists, blockquotes, and horizontal rules. Edit mode continues to show raw markdown in textareas.

## Test plan

- [ ] Verify filter finds issues by label name (e.g., search "bug" matches issues tagged "bug")
- [ ] Verify filter still works for title search and issue number (#N)
- [ ] Verify plugin colors match the host app in both light and dark themes
- [ ] Verify issue body renders markdown (headings, bold, code blocks, links, lists)
- [ ] Verify comments render markdown properly
- [ ] Verify edit mode shows raw markdown text (not rendered)
- [ ] Run `npm run test` — 46 tests pass (manifest, helpers, filter, markdown parsing)
- [ ] Run `npm run typecheck` — no errors
- [ ] Run `npm run build` — dist/main.js builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)