### PR TITLE
feat: Azure DevOps Work Items plugin

### DIFF
--- a/plugins/ado-work-items/dist/main.js
+++ b/plugins/ado-work-items/dist/main.js
@@ -1,0 +1,1657 @@
+// src/main.tsx
+import { Fragment, jsx, jsxs } from "react/jsx-runtime";
+var React = globalThis.React;
+var { useState, useEffect, useCallback, useRef, useMemo } = React;
+var workItemState = {
+  selectedId: null,
+  creatingNew: false,
+  items: [],
+  loading: false,
+  needsRefresh: false,
+  stateFilter: "",
+  typeFilter: "",
+  searchQuery: "",
+  listeners: /* @__PURE__ */ new Set(),
+  setSelectedItem(id) {
+    this.selectedId = id;
+    this.creatingNew = false;
+    this.notify();
+  },
+  setCreatingNew(val) {
+    this.creatingNew = val;
+    if (val) this.selectedId = null;
+    this.notify();
+  },
+  setItems(items) {
+    this.items = items;
+    this.notify();
+  },
+  setLoading(loading) {
+    this.loading = loading;
+    this.notify();
+  },
+  setStateFilter(filter) {
+    this.stateFilter = filter;
+    this.requestRefresh();
+  },
+  setTypeFilter(filter) {
+    this.typeFilter = filter;
+    this.requestRefresh();
+  },
+  setSearchQuery(query) {
+    this.searchQuery = query;
+    this.notify();
+  },
+  pendingAction: null,
+  triggerAction(action) {
+    if (this.selectedId === null) return;
+    this.pendingAction = action;
+    this.notify();
+  },
+  consumeAction() {
+    const action = this.pendingAction;
+    this.pendingAction = null;
+    return action;
+  },
+  requestRefresh() {
+    this.needsRefresh = true;
+    this.notify();
+  },
+  subscribe(fn) {
+    this.listeners.add(fn);
+    return () => {
+      this.listeners.delete(fn);
+    };
+  },
+  notify() {
+    for (const fn of this.listeners) fn();
+  },
+  reset() {
+    this.selectedId = null;
+    this.creatingNew = false;
+    this.items = [];
+    this.loading = false;
+    this.needsRefresh = false;
+    this.pendingAction = null;
+    this.stateFilter = "";
+    this.typeFilter = "";
+    this.searchQuery = "";
+    this.listeners.clear();
+  }
+};
+function relativeTime(dateStr) {
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  const diffMs = now - then;
+  const diffMin = Math.floor(diffMs / 6e4);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffH = Math.floor(diffMin / 60);
+  if (diffH < 24) return `${diffH}h ago`;
+  const diffD = Math.floor(diffH / 24);
+  if (diffD < 30) return `${diffD}d ago`;
+  const diffMo = Math.floor(diffD / 30);
+  return `${diffMo}mo ago`;
+}
+function getConfig(api) {
+  return {
+    organization: (api.settings.get("organization") || "").replace(/\/+$/, ""),
+    project: api.settings.get("project") || "",
+    team: api.settings.get("team") || "",
+    defaultWorkItemType: api.settings.get("defaultWorkItemType") || "Task",
+    areaPath: api.settings.get("areaPath") || "",
+    iterationPath: api.settings.get("iterationPath") || "",
+    queryPath: api.settings.get("queryPath") || ""
+  };
+}
+function baseArgs(config) {
+  const args = [];
+  if (config.organization) args.push("--org", config.organization);
+  if (config.project) args.push("--project", config.project);
+  return args;
+}
+function typeColor(type) {
+  switch (type.toLowerCase()) {
+    case "bug":
+      return "#cc293d";
+    case "task":
+      return "#f2cb1d";
+    case "user story":
+      return "#009ccc";
+    case "product backlog item":
+      return "#009ccc";
+    case "feature":
+      return "#773b93";
+    case "epic":
+      return "#ff7b00";
+    case "issue":
+      return "#009ccc";
+    case "impediment":
+      return "#cc293d";
+    default:
+      return "#888";
+  }
+}
+function stateColor(state) {
+  const s = state.toLowerCase();
+  if (s === "new" || s === "to do" || s === "proposed")
+    return { bg: "rgba(180,180,180,0.1)", fg: "#b4b4b4", border: "rgba(180,180,180,0.3)" };
+  if (s === "active" || s === "in progress" || s === "committed" || s === "doing")
+    return { bg: "rgba(0,122,204,0.1)", fg: "#007acc", border: "rgba(0,122,204,0.3)" };
+  if (s === "resolved" || s === "done")
+    return { bg: "rgba(64,200,100,0.1)", fg: "#4ade80", border: "rgba(64,200,100,0.3)" };
+  if (s === "closed" || s === "removed")
+    return { bg: "rgba(168,85,247,0.1)", fg: "#c084fc", border: "rgba(168,85,247,0.3)" };
+  return { bg: "rgba(180,180,180,0.1)", fg: "#b4b4b4", border: "rgba(180,180,180,0.3)" };
+}
+function priorityLabel(p) {
+  switch (p) {
+    case 1:
+      return "Critical";
+    case 2:
+      return "High";
+    case 3:
+      return "Medium";
+    case 4:
+      return "Low";
+    default:
+      return "";
+  }
+}
+function buildWorkItemUrl(config, id) {
+  return `${config.organization}/${encodeURIComponent(config.project)}/_workitems/edit/${id}`;
+}
+function parseWorkItemDetail(raw, config) {
+  const fields = raw.fields;
+  if (!fields) {
+    return {
+      id: raw.id || 0,
+      title: "",
+      state: "",
+      workItemType: "",
+      assignedTo: "",
+      changedDate: "",
+      tags: "",
+      priority: 0,
+      areaPath: "",
+      iterationPath: "",
+      description: "",
+      url: "",
+      createdBy: "",
+      createdDate: "",
+      reason: "",
+      comments: []
+    };
+  }
+  const assignedToField = fields["System.AssignedTo"];
+  const assignedTo = typeof assignedToField === "object" && assignedToField !== null ? assignedToField.displayName || assignedToField.uniqueName || "" : typeof assignedToField === "string" ? assignedToField : "";
+  const createdByField = fields["System.CreatedBy"];
+  const createdBy = typeof createdByField === "object" && createdByField !== null ? createdByField.displayName || createdByField.uniqueName || "" : typeof createdByField === "string" ? createdByField : "";
+  return {
+    id: raw.id || 0,
+    title: fields["System.Title"] || "",
+    state: fields["System.State"] || "",
+    workItemType: fields["System.WorkItemType"] || "",
+    assignedTo,
+    changedDate: fields["System.ChangedDate"] || "",
+    tags: fields["System.Tags"] || "",
+    priority: fields["Microsoft.VSTS.Common.Priority"] || 0,
+    areaPath: fields["System.AreaPath"] || "",
+    iterationPath: fields["System.IterationPath"] || "",
+    description: fields["System.Description"] || "",
+    url: buildWorkItemUrl(config, raw.id || 0),
+    createdBy,
+    createdDate: fields["System.CreatedDate"] || "",
+    reason: fields["System.Reason"] || "",
+    comments: []
+  };
+}
+async function fetchWorkItemsByIds(api, config, ids) {
+  if (ids.length === 0) return [];
+  const batchSize = 50;
+  const results = [];
+  for (let i = 0; i < ids.length; i += batchSize) {
+    const batch = ids.slice(i, i + batchSize);
+    const args = [
+      "boards",
+      "work-item",
+      "show",
+      "--id",
+      batch.join(","),
+      "--output",
+      "json",
+      ...baseArgs(config)
+    ];
+    const r = await api.process.exec("az", args, { timeout: 3e4 });
+    if (r.exitCode !== 0 || !r.stdout.trim()) continue;
+    const parsed = JSON.parse(r.stdout);
+    const items = Array.isArray(parsed) ? parsed : [parsed];
+    for (const raw of items) {
+      const fields = raw.fields;
+      if (!fields) continue;
+      const assignedToField = fields["System.AssignedTo"];
+      const assignedTo = typeof assignedToField === "object" && assignedToField !== null ? assignedToField.displayName || "" : typeof assignedToField === "string" ? assignedToField : "";
+      results.push({
+        id: raw.id || 0,
+        title: fields["System.Title"] || "",
+        state: fields["System.State"] || "",
+        workItemType: fields["System.WorkItemType"] || "",
+        assignedTo,
+        changedDate: fields["System.ChangedDate"] || "",
+        tags: fields["System.Tags"] || "",
+        priority: fields["Microsoft.VSTS.Common.Priority"] || 0,
+        areaPath: fields["System.AreaPath"] || "",
+        iterationPath: fields["System.IterationPath"] || ""
+      });
+    }
+  }
+  return results;
+}
+async function fetchComments(api, config, workItemId) {
+  const url = `${config.organization}/${encodeURIComponent(config.project)}/_apis/wit/workItems/${workItemId}/comments?api-version=7.1-preview.4`;
+  const r = await api.process.exec("az", ["rest", "--method", "get", "--url", url, "--output", "json"], { timeout: 3e4 });
+  if (r.exitCode !== 0 || !r.stdout.trim()) return [];
+  try {
+    const data = JSON.parse(r.stdout);
+    const comments = [];
+    if (data.comments && Array.isArray(data.comments)) {
+      for (const c of data.comments) {
+        comments.push({
+          author: c.createdBy?.displayName || c.createdBy?.uniqueName || "Unknown",
+          body: c.text || "",
+          createdDate: c.createdDate || ""
+        });
+      }
+    }
+    return comments;
+  } catch {
+    return [];
+  }
+}
+var pluginApi = null;
+function activate(ctx, api) {
+  pluginApi = api;
+  api.logging.info("Azure DevOps Work Items activated");
+  ctx.subscriptions.push(
+    api.commands.register("ado-work-items.refresh", () => {
+      workItemState.requestRefresh();
+    })
+  );
+  ctx.subscriptions.push(
+    api.commands.register("ado-work-items.create", () => {
+      workItemState.setCreatingNew(true);
+    })
+  );
+  ctx.subscriptions.push(
+    api.commands.register("ado-work-items.assignAgent", () => {
+      if (!workItemState.selectedId) {
+        api.ui.showError("Select a work item first");
+        return;
+      }
+      workItemState.triggerAction("assignAgent");
+    })
+  );
+  ctx.subscriptions.push(
+    api.commands.register("ado-work-items.toggleState", () => {
+      if (!workItemState.selectedId) {
+        api.ui.showError("Select a work item first");
+        return;
+      }
+      workItemState.triggerAction("toggleState");
+    })
+  );
+  ctx.subscriptions.push(
+    api.commands.register("ado-work-items.viewInBrowser", () => {
+      if (!workItemState.selectedId) {
+        api.ui.showError("Select a work item first");
+        return;
+      }
+      workItemState.triggerAction("viewInBrowser");
+    })
+  );
+}
+function deactivate() {
+  pluginApi = null;
+  workItemState.reset();
+}
+function buildAgentPrompt(item) {
+  const tags = item.tags ? `Tags: ${item.tags}` : "";
+  return [
+    "Review and work on the following Azure DevOps work item:",
+    "",
+    `Work Item #${item.id}: ${item.title}`,
+    `Type: ${item.workItemType}`,
+    `State: ${item.state}`,
+    `Priority: ${priorityLabel(item.priority) || String(item.priority)}`,
+    item.assignedTo ? `Assigned To: ${item.assignedTo}` : "",
+    item.areaPath ? `Area: ${item.areaPath}` : "",
+    item.iterationPath ? `Iteration: ${item.iterationPath}` : "",
+    tags,
+    "",
+    item.description ? stripHtml(item.description) : "(no description)"
+  ].filter(Boolean).join("\n");
+}
+function stripHtml(html) {
+  return html.replace(/<br\s*\/?>/gi, "\n").replace(/<\/p>/gi, "\n").replace(/<\/div>/gi, "\n").replace(/<\/li>/gi, "\n").replace(/<[^>]+>/g, "").replace(/&amp;/g, "&").replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&quot;/g, '"').replace(/&#39;/g, "'").replace(/&nbsp;/g, " ").replace(/\n{3,}/g, "\n\n").trim();
+}
+function statusBadgeStyle(status) {
+  const base = {
+    fontSize: "9px",
+    padding: "1px 4px",
+    borderRadius: "3px",
+    display: "inline-block"
+  };
+  switch (status) {
+    case "sleeping":
+      return { ...base, background: "rgba(64,200,100,0.15)", color: "#4ade80" };
+    case "running":
+      return { ...base, background: "rgba(234,179,8,0.15)", color: "#facc15" };
+    case "error":
+      return { ...base, background: "rgba(239,68,68,0.15)", color: "#f87171" };
+    default:
+      return base;
+  }
+}
+function SendToAgentDialog({
+  api,
+  item,
+  onClose
+}) {
+  const [instructions, setInstructions] = useState("");
+  const [saveAsDefault, setSaveAsDefault] = useState(false);
+  const [durableAgents, setDurableAgents] = useState([]);
+  const [defaultLoaded, setDefaultLoaded] = useState(false);
+  const [selectedAgentId, setSelectedAgentId] = useState(null);
+  const overlayRef = useRef(null);
+  const AgentAvatar = api.widgets.AgentAvatar;
+  useEffect(() => {
+    const agents = api.agents.list().filter((a) => a.kind === "durable");
+    setDurableAgents(agents);
+    api.storage.projectLocal.read("defaultAgentInstructions").then((saved) => {
+      if (typeof saved === "string" && saved.length > 0) {
+        setInstructions(saved);
+      }
+      setDefaultLoaded(true);
+    }).catch(() => {
+      setDefaultLoaded(true);
+    });
+  }, [api]);
+  useEffect(() => {
+    const handleMouseDown = (e) => {
+      if (overlayRef.current && e.target === overlayRef.current) onClose();
+    };
+    document.addEventListener("mousedown", handleMouseDown);
+    return () => document.removeEventListener("mousedown", handleMouseDown);
+  }, [onClose]);
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+  const buildMission = useCallback(() => {
+    const ctx = buildAgentPrompt(item);
+    if (instructions.trim()) return `${ctx}
+
+Additional instructions:
+${instructions.trim()}`;
+    return ctx;
+  }, [item, instructions]);
+  const persistDefault = useCallback(async () => {
+    if (saveAsDefault && instructions.trim()) {
+      await api.storage.projectLocal.write("defaultAgentInstructions", instructions.trim());
+    }
+  }, [api, saveAsDefault, instructions]);
+  const handleConfirm = useCallback(async () => {
+    const agent = durableAgents.find((a) => a.id === selectedAgentId);
+    if (!agent) return;
+    if (agent.status === "running") {
+      const ok = await api.ui.showConfirm(
+        `"${agent.name}" is currently running. Assigning this work item will interrupt its current work. Continue?`
+      );
+      if (!ok) return;
+      await api.agents.kill(agent.id);
+    }
+    const mission = buildMission();
+    try {
+      await persistDefault();
+      await api.agents.resume(agent.id, { mission });
+      api.ui.showNotice(`Agent "${agent.name}" assigned to work item #${item.id}`);
+    } catch {
+      api.ui.showError(`Failed to assign agent to work item #${item.id}`);
+    }
+    onClose();
+  }, [durableAgents, selectedAgentId, api, item, buildMission, persistDefault, onClose]);
+  return /* @__PURE__ */ jsx(
+    "div",
+    {
+      ref: overlayRef,
+      style: {
+        position: "absolute",
+        inset: 0,
+        zIndex: 50,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "rgba(0,0,0,0.5)"
+      },
+      children: /* @__PURE__ */ jsxs(
+        "div",
+        {
+          style: {
+            background: "var(--panel-bg, #1e1e2e)",
+            border: "1px solid var(--border-color, #333)",
+            borderRadius: "8px",
+            padding: "16px",
+            width: "320px",
+            maxHeight: "80vh",
+            overflow: "auto",
+            boxShadow: "0 8px 32px rgba(0,0,0,0.4)"
+          },
+          children: [
+            /* @__PURE__ */ jsx("div", { style: { fontSize: "14px", fontWeight: 500, color: "var(--text-primary, #e0e0e0)", marginBottom: "4px" }, children: "Assign to Agent" }),
+            /* @__PURE__ */ jsxs("div", { style: { fontSize: "10px", color: "var(--text-secondary, #888)", marginBottom: "12px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: [
+              "#",
+              item.id,
+              " ",
+              item.title
+            ] }),
+            /* @__PURE__ */ jsx(
+              "textarea",
+              {
+                value: instructions,
+                onChange: (e) => setInstructions(e.target.value),
+                placeholder: "Additional instructions (optional)",
+                rows: 3,
+                autoFocus: true,
+                style: {
+                  width: "100%",
+                  padding: "6px 8px",
+                  fontSize: "12px",
+                  background: "var(--input-bg, #1a1a2e)",
+                  border: "1px solid var(--border-color, #333)",
+                  borderRadius: "4px",
+                  color: "var(--text-primary, #e0e0e0)",
+                  resize: "none",
+                  fontFamily: "var(--font-family)",
+                  boxSizing: "border-box"
+                }
+              }
+            ),
+            /* @__PURE__ */ jsx("div", { style: { marginTop: "12px", display: "flex", flexDirection: "column", gap: "4px" }, children: durableAgents.length === 0 ? /* @__PURE__ */ jsx("div", { style: { fontSize: "12px", color: "var(--text-secondary, #888)", textAlign: "center", padding: "16px 0" }, children: "No durable agents found" }) : durableAgents.map((agent) => {
+              const isSelected = selectedAgentId === agent.id;
+              return /* @__PURE__ */ jsxs(
+                "button",
+                {
+                  onClick: () => setSelectedAgentId((prev) => prev === agent.id ? null : agent.id),
+                  style: {
+                    width: "100%",
+                    textAlign: "left",
+                    padding: "8px 10px",
+                    fontSize: "12px",
+                    color: "var(--text-primary, #e0e0e0)",
+                    borderRadius: "4px",
+                    border: isSelected ? "1px solid var(--accent-color, #4a6cf7)" : "1px solid transparent",
+                    background: isSelected ? "rgba(74,108,247,0.1)" : "transparent",
+                    cursor: "pointer",
+                    fontFamily: "var(--font-family)"
+                  },
+                  children: [
+                    /* @__PURE__ */ jsxs("div", { style: { display: "flex", alignItems: "center", gap: "6px" }, children: [
+                      /* @__PURE__ */ jsx(AgentAvatar, { agentId: agent.id, size: "sm", showStatusRing: true }),
+                      /* @__PURE__ */ jsx("span", { style: { fontWeight: 500 }, children: agent.name }),
+                      /* @__PURE__ */ jsx("span", { style: statusBadgeStyle(agent.status), children: agent.status })
+                    ] }),
+                    /* @__PURE__ */ jsx("div", { style: { fontSize: "10px", color: "var(--text-secondary, #888)", marginTop: "2px", paddingLeft: "22px" }, children: agent.status === "running" ? "Will interrupt current work" : "Assign work item to this agent" })
+                  ]
+                },
+                agent.id
+              );
+            }) }),
+            /* @__PURE__ */ jsxs(
+              "div",
+              {
+                style: {
+                  marginTop: "12px",
+                  paddingTop: "12px",
+                  borderTop: "1px solid var(--border-color, #333)",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between"
+                },
+                children: [
+                  defaultLoaded && /* @__PURE__ */ jsxs(
+                    "label",
+                    {
+                      style: {
+                        display: "flex",
+                        alignItems: "center",
+                        gap: "6px",
+                        cursor: "pointer",
+                        userSelect: "none"
+                      },
+                      children: [
+                        /* @__PURE__ */ jsx(
+                          "input",
+                          {
+                            type: "checkbox",
+                            checked: saveAsDefault,
+                            onChange: (e) => setSaveAsDefault(e.target.checked)
+                          }
+                        ),
+                        /* @__PURE__ */ jsx("span", { style: { fontSize: "10px", color: "var(--text-secondary, #888)" }, children: "Save as default" })
+                      ]
+                    }
+                  ),
+                  /* @__PURE__ */ jsxs("div", { style: { display: "flex", gap: "6px", marginLeft: "auto" }, children: [
+                    /* @__PURE__ */ jsx("button", { onClick: onClose, style: btnSecondarySmall, children: "Cancel" }),
+                    /* @__PURE__ */ jsx(
+                      "button",
+                      {
+                        onClick: handleConfirm,
+                        disabled: !selectedAgentId,
+                        style: {
+                          ...btnPrimarySmall,
+                          opacity: selectedAgentId ? 1 : 0.4,
+                          cursor: selectedAgentId ? "pointer" : "default"
+                        },
+                        children: "Confirm"
+                      }
+                    )
+                  ] })
+                ]
+              }
+            )
+          ]
+        }
+      )
+    }
+  );
+}
+function StatePickerDialog({
+  api,
+  item,
+  config,
+  onClose,
+  onStateChanged
+}) {
+  const [states, setStates] = useState([]);
+  const [loadingStates, setLoadingStates] = useState(true);
+  const overlayRef = useRef(null);
+  useEffect(() => {
+    const commonStates = {
+      "bug": ["New", "Active", "Resolved", "Closed"],
+      "task": ["New", "Active", "Closed"],
+      "user story": ["New", "Active", "Resolved", "Closed"],
+      "product backlog item": ["New", "Approved", "Committed", "Done"],
+      "feature": ["New", "Active", "Resolved", "Closed"],
+      "epic": ["New", "Active", "Resolved", "Closed"],
+      "issue": ["To Do", "Doing", "Done"],
+      "impediment": ["Open", "Closed"]
+    };
+    const key = item.workItemType.toLowerCase();
+    const available = commonStates[key] || ["New", "Active", "Resolved", "Closed"];
+    setStates(available.filter((s) => s !== item.state));
+    setLoadingStates(false);
+  }, [item]);
+  useEffect(() => {
+    const handleMouseDown = (e) => {
+      if (overlayRef.current && e.target === overlayRef.current) onClose();
+    };
+    document.addEventListener("mousedown", handleMouseDown);
+    return () => document.removeEventListener("mousedown", handleMouseDown);
+  }, [onClose]);
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+  const handleSelectState = useCallback(async (newState) => {
+    const args = [
+      "boards",
+      "work-item",
+      "update",
+      "--id",
+      String(item.id),
+      "--state",
+      newState,
+      "--output",
+      "json",
+      ...baseArgs(config)
+    ];
+    const r = await api.process.exec("az", args, { timeout: 3e4 });
+    if (r.exitCode === 0) {
+      api.ui.showNotice(`Work item #${item.id} moved to "${newState}"`);
+      onStateChanged();
+    } else {
+      api.ui.showError(r.stderr.trim() || `Failed to change state to "${newState}"`);
+    }
+    onClose();
+  }, [item, config, api, onClose, onStateChanged]);
+  return /* @__PURE__ */ jsx(
+    "div",
+    {
+      ref: overlayRef,
+      style: {
+        position: "absolute",
+        inset: 0,
+        zIndex: 50,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "rgba(0,0,0,0.5)"
+      },
+      children: /* @__PURE__ */ jsxs(
+        "div",
+        {
+          style: {
+            background: "var(--panel-bg, #1e1e2e)",
+            border: "1px solid var(--border-color, #333)",
+            borderRadius: "8px",
+            padding: "16px",
+            width: "260px",
+            boxShadow: "0 8px 32px rgba(0,0,0,0.4)"
+          },
+          children: [
+            /* @__PURE__ */ jsx("div", { style: { fontSize: "14px", fontWeight: 500, color: "var(--text-primary, #e0e0e0)", marginBottom: "4px" }, children: "Change State" }),
+            /* @__PURE__ */ jsxs("div", { style: { fontSize: "10px", color: "var(--text-secondary, #888)", marginBottom: "12px" }, children: [
+              "Current: ",
+              item.state
+            ] }),
+            loadingStates ? /* @__PURE__ */ jsxs("div", { style: { fontSize: "12px", color: "var(--text-secondary, #888)", textAlign: "center", padding: "8px" }, children: [
+              "Loading",
+              "\u2026"
+            ] }) : /* @__PURE__ */ jsx("div", { style: { display: "flex", flexDirection: "column", gap: "4px" }, children: states.map((s) => {
+              const colors = stateColor(s);
+              return /* @__PURE__ */ jsx(
+                "button",
+                {
+                  onClick: () => handleSelectState(s),
+                  style: {
+                    width: "100%",
+                    textAlign: "left",
+                    padding: "6px 10px",
+                    fontSize: "12px",
+                    color: colors.fg,
+                    borderRadius: "4px",
+                    border: `1px solid ${colors.border}`,
+                    background: colors.bg,
+                    cursor: "pointer",
+                    fontFamily: "var(--font-family)"
+                  },
+                  children: s
+                },
+                s
+              );
+            }) }),
+            /* @__PURE__ */ jsx("div", { style: { marginTop: "12px", display: "flex", justifyContent: "flex-end" }, children: /* @__PURE__ */ jsx("button", { onClick: onClose, style: btnSecondarySmall, children: "Cancel" }) })
+          ]
+        }
+      )
+    }
+  );
+}
+function ConfigWarning() {
+  return /* @__PURE__ */ jsx("div", { style: { ...sidebarContainer, justifyContent: "center", alignItems: "center" }, children: /* @__PURE__ */ jsxs("div", { style: { padding: "16px", textAlign: "center" }, children: [
+    /* @__PURE__ */ jsx("div", { style: { fontSize: "12px", color: "var(--text-error, #f87171)", marginBottom: "8px" }, children: "Plugin not configured" }),
+    /* @__PURE__ */ jsx("div", { style: { fontSize: "11px", color: "var(--text-secondary, #888)", marginBottom: "12px", lineHeight: 1.5 }, children: "Open the plugin settings and configure your Azure DevOps Organization URL and Project name. The Azure CLI must also be installed with the azure-devops extension." })
+  ] }) });
+}
+function SidebarPanel({ api }) {
+  const [items, setItems] = useState(workItemState.items);
+  const [selected, setSelected] = useState(workItemState.selectedId);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [needsRefresh, setNeedsRefresh] = useState(false);
+  const [stateFilter, setStateFilter] = useState(workItemState.stateFilter);
+  const [typeFilter, setTypeFilter] = useState(workItemState.typeFilter);
+  const [searchQuery, setSearchQuery] = useState(workItemState.searchQuery);
+  const mountedRef = useRef(true);
+  const config = getConfig(api);
+  useEffect(() => {
+    mountedRef.current = true;
+    const unsub = workItemState.subscribe(() => {
+      if (!mountedRef.current) return;
+      setItems([...workItemState.items]);
+      setSelected(workItemState.selectedId);
+      setLoading(workItemState.loading);
+      setNeedsRefresh(workItemState.needsRefresh);
+      setStateFilter(workItemState.stateFilter);
+      setTypeFilter(workItemState.typeFilter);
+      setSearchQuery(workItemState.searchQuery);
+    });
+    return () => {
+      mountedRef.current = false;
+      unsub();
+    };
+  }, []);
+  const fetchItems = useCallback(async () => {
+    if (!config.organization || !config.project) return;
+    workItemState.setLoading(true);
+    setError(null);
+    try {
+      let ids = [];
+      if (config.queryPath) {
+        const args = [
+          "boards",
+          "query",
+          "--path",
+          config.queryPath,
+          "--output",
+          "json",
+          ...baseArgs(config)
+        ];
+        const r = await api.process.exec("az", args, { timeout: 3e4 });
+        if (!mountedRef.current) return;
+        if (r.exitCode !== 0 || !r.stdout.trim()) {
+          setError("Failed to execute saved query. Check the query path in settings.");
+          workItemState.setLoading(false);
+          return;
+        }
+        const parsed = JSON.parse(r.stdout);
+        ids = parsed.map(
+          (wi) => wi.id || 0
+        ).filter(Boolean);
+      } else {
+        const conditions = [
+          `[System.TeamProject] = '${config.project}'`
+        ];
+        if (workItemState.stateFilter) {
+          conditions.push(`[System.State] = '${workItemState.stateFilter}'`);
+        }
+        if (workItemState.typeFilter) {
+          conditions.push(`[System.WorkItemType] = '${workItemState.typeFilter}'`);
+        }
+        if (config.areaPath) {
+          conditions.push(`[System.AreaPath] UNDER '${config.areaPath}'`);
+        }
+        if (config.iterationPath) {
+          conditions.push(`[System.IterationPath] UNDER '${config.iterationPath}'`);
+        }
+        const wiql = `SELECT [System.Id] FROM WorkItems WHERE ${conditions.join(" AND ")} ORDER BY [System.ChangedDate] DESC`;
+        const args = [
+          "boards",
+          "query",
+          "--wiql",
+          wiql,
+          "--output",
+          "json",
+          ...baseArgs(config)
+        ];
+        const r = await api.process.exec("az", args, { timeout: 3e4 });
+        if (!mountedRef.current) return;
+        if (r.exitCode !== 0 || !r.stdout.trim()) {
+          setError("Failed to query work items. Is the Azure CLI installed and authenticated?");
+          workItemState.setLoading(false);
+          return;
+        }
+        const parsed = JSON.parse(r.stdout);
+        ids = parsed.map(
+          (wi) => wi.id || 0
+        ).filter(Boolean);
+      }
+      ids = ids.slice(0, 50);
+      if (ids.length === 0) {
+        workItemState.setItems([]);
+        workItemState.setLoading(false);
+        return;
+      }
+      const results = await fetchWorkItemsByIds(api, config, ids);
+      if (!mountedRef.current) return;
+      workItemState.setItems(results);
+    } catch {
+      if (!mountedRef.current) return;
+      setError("Failed to load work items. Is the Azure CLI installed and authenticated?");
+    } finally {
+      workItemState.setLoading(false);
+    }
+  }, [api, config.organization, config.project, config.areaPath, config.iterationPath, config.queryPath]);
+  useEffect(() => {
+    if (workItemState.items.length === 0 && config.organization && config.project) {
+      fetchItems();
+    }
+  }, [fetchItems]);
+  useEffect(() => {
+    if (needsRefresh) {
+      workItemState.needsRefresh = false;
+      fetchItems();
+    }
+  }, [needsRefresh, fetchItems]);
+  useEffect(() => {
+    const unsub = api.settings.onChange(() => {
+      workItemState.requestRefresh();
+    });
+    return () => unsub.dispose();
+  }, [api]);
+  const filteredItems = useMemo(() => {
+    if (!searchQuery.trim()) return items;
+    const q = searchQuery.toLowerCase();
+    return items.filter(
+      (i) => i.title.toLowerCase().includes(q) || `#${i.id}`.includes(q)
+    );
+  }, [items, searchQuery]);
+  const availableStates = useMemo(() => {
+    const states = new Set(items.map((i) => i.state));
+    return Array.from(states).sort();
+  }, [items]);
+  const availableTypes = useMemo(() => {
+    const types = new Set(items.map((i) => i.workItemType));
+    return Array.from(types).sort();
+  }, [items]);
+  if (!config.organization || !config.project) {
+    return /* @__PURE__ */ jsx(ConfigWarning, {});
+  }
+  if (error) {
+    return /* @__PURE__ */ jsx("div", { style: { ...sidebarContainer, justifyContent: "center", alignItems: "center" }, children: /* @__PURE__ */ jsxs("div", { style: { padding: "16px", textAlign: "center" }, children: [
+      /* @__PURE__ */ jsx("div", { style: { fontSize: "12px", color: "var(--text-error, #f87171)", marginBottom: "8px" }, children: "Could not load work items" }),
+      /* @__PURE__ */ jsx("div", { style: { fontSize: "11px", color: "var(--text-secondary, #888)", marginBottom: "12px" }, children: error }),
+      /* @__PURE__ */ jsx("button", { onClick: () => fetchItems(), style: btnSecondarySmall, children: "Retry" })
+    ] }) });
+  }
+  return /* @__PURE__ */ jsxs("div", { style: sidebarContainer, children: [
+    /* @__PURE__ */ jsxs("div", { style: sidebarHeader, children: [
+      /* @__PURE__ */ jsx("span", { style: { fontSize: "12px", fontWeight: 500, color: "var(--text-primary, #e0e0e0)" }, children: "Work Items" }),
+      /* @__PURE__ */ jsxs("div", { style: { display: "flex", alignItems: "center", gap: "4px" }, children: [
+        /* @__PURE__ */ jsx(
+          "button",
+          {
+            onClick: () => fetchItems(),
+            disabled: loading,
+            title: "Refresh work items",
+            style: sidebarHeaderBtn,
+            children: "\u21BB"
+          }
+        ),
+        /* @__PURE__ */ jsx(
+          "button",
+          {
+            onClick: () => workItemState.setCreatingNew(true),
+            title: "Create a new work item",
+            style: sidebarHeaderBtn,
+            children: "+ New"
+          }
+        )
+      ] })
+    ] }),
+    /* @__PURE__ */ jsxs("div", { style: { padding: "6px 8px", borderBottom: "1px solid var(--border-color, #222)", display: "flex", gap: "4px", alignItems: "center", flexWrap: "wrap" }, children: [
+      /* @__PURE__ */ jsx(
+        "input",
+        {
+          type: "text",
+          value: searchQuery,
+          onChange: (e) => workItemState.setSearchQuery(e.target.value),
+          placeholder: "Filter\\u2026",
+          style: {
+            flex: 1,
+            minWidth: "60px",
+            padding: "4px 6px",
+            fontSize: "11px",
+            border: "1px solid var(--border-color, #333)",
+            borderRadius: "4px",
+            background: "var(--input-bg, #1a1a2e)",
+            color: "var(--text-primary, #e0e0e0)",
+            fontFamily: "var(--font-family)",
+            outline: "none"
+          }
+        }
+      ),
+      /* @__PURE__ */ jsxs(
+        "select",
+        {
+          value: stateFilter,
+          onChange: (e) => workItemState.setStateFilter(e.target.value),
+          style: filterSelect,
+          children: [
+            /* @__PURE__ */ jsx("option", { value: "", children: "All States" }),
+            availableStates.map((s) => /* @__PURE__ */ jsx("option", { value: s, children: s }, s))
+          ]
+        }
+      ),
+      /* @__PURE__ */ jsxs(
+        "select",
+        {
+          value: typeFilter,
+          onChange: (e) => workItemState.setTypeFilter(e.target.value),
+          style: filterSelect,
+          children: [
+            /* @__PURE__ */ jsx("option", { value: "", children: "All Types" }),
+            availableTypes.map((t) => /* @__PURE__ */ jsx("option", { value: t, children: t }, t))
+          ]
+        }
+      )
+    ] }),
+    /* @__PURE__ */ jsx("div", { style: { flex: 1, overflowY: "auto" }, children: loading && items.length === 0 ? /* @__PURE__ */ jsxs("div", { style: { padding: "16px", textAlign: "center", fontSize: "12px", color: "var(--text-secondary, #888)" }, children: [
+      "Loading work items",
+      "\u2026"
+    ] }) : filteredItems.length === 0 ? /* @__PURE__ */ jsx("div", { style: { padding: "16px", textAlign: "center", fontSize: "12px", color: "var(--text-secondary, #888)" }, children: searchQuery ? "No matching work items" : "No work items found" }) : /* @__PURE__ */ jsx("div", { style: { padding: "2px 0" }, children: filteredItems.map((item) => /* @__PURE__ */ jsxs(
+      "div",
+      {
+        onClick: () => workItemState.setSelectedItem(item.id),
+        style: {
+          padding: "8px 10px",
+          cursor: "pointer",
+          background: item.id === selected ? "var(--item-active-bg, #2a2a4a)" : "transparent"
+        },
+        children: [
+          /* @__PURE__ */ jsxs("div", { style: { display: "flex", alignItems: "center", gap: "6px", minWidth: 0 }, children: [
+            /* @__PURE__ */ jsx(
+              "span",
+              {
+                style: {
+                  width: "3px",
+                  height: "14px",
+                  borderRadius: "2px",
+                  background: typeColor(item.workItemType),
+                  flexShrink: 0
+                }
+              }
+            ),
+            /* @__PURE__ */ jsxs("span", { style: { fontSize: "10px", color: "var(--text-secondary, #888)", flexShrink: 0 }, children: [
+              "#",
+              item.id
+            ] }),
+            /* @__PURE__ */ jsx("span", { style: { fontSize: "12px", color: "var(--text-primary, #e0e0e0)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: item.title })
+          ] }),
+          /* @__PURE__ */ jsxs("div", { style: { display: "flex", alignItems: "center", gap: "4px", marginTop: "4px", paddingLeft: "9px" }, children: [
+            /* @__PURE__ */ jsx("span", { style: { fontSize: "9px", color: typeColor(item.workItemType), flexShrink: 0 }, children: item.workItemType }),
+            (() => {
+              const colors = stateColor(item.state);
+              return /* @__PURE__ */ jsx(
+                "span",
+                {
+                  style: {
+                    fontSize: "9px",
+                    padding: "0 5px",
+                    borderRadius: "10px",
+                    backgroundColor: colors.bg,
+                    color: colors.fg,
+                    border: `1px solid ${colors.border}`,
+                    flexShrink: 0
+                  },
+                  children: item.state
+                }
+              );
+            })(),
+            item.assignedTo && /* @__PURE__ */ jsx("span", { style: { fontSize: "9px", color: "var(--text-secondary, #666)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: item.assignedTo }),
+            /* @__PURE__ */ jsx("span", { style: { fontSize: "10px", color: "var(--text-secondary, #888)", marginLeft: "auto", flexShrink: 0 }, children: relativeTime(item.changedDate) })
+          ] })
+        ]
+      },
+      item.id
+    )) }) })
+  ] });
+}
+function MainPanel({ api }) {
+  const [selected, setSelected] = useState(workItemState.selectedId);
+  const [creatingNew, setCreatingNew] = useState(workItemState.creatingNew);
+  const [detail, setDetail] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [showAgentDialog, setShowAgentDialog] = useState(false);
+  const [showStateDialog, setShowStateDialog] = useState(false);
+  const [detailVersion, setDetailVersion] = useState(0);
+  const config = getConfig(api);
+  const [newType, setNewType] = useState(config.defaultWorkItemType || "Task");
+  const [newTitle, setNewTitle] = useState("");
+  const [newDescription, setNewDescription] = useState("");
+  const [newAreaPath, setNewAreaPath] = useState(config.areaPath || "");
+  const [newIterationPath, setNewIterationPath] = useState(config.iterationPath || "");
+  const [newPriority, setNewPriority] = useState("3");
+  const [newTags, setNewTags] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [editTitle, setEditTitle] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+  const [editAssignedTo, setEditAssignedTo] = useState("");
+  const [editTags, setEditTags] = useState("");
+  const [commentBody, setCommentBody] = useState("");
+  const handleToggleStateRef = useRef(null);
+  const handleViewInBrowserRef = useRef(null);
+  useEffect(() => {
+    const unsub = workItemState.subscribe(() => {
+      setSelected(workItemState.selectedId);
+      setCreatingNew(workItemState.creatingNew);
+      const action = workItemState.consumeAction();
+      if (action === "assignAgent") setShowAgentDialog(true);
+      if (action === "toggleState") handleToggleStateRef.current?.();
+      if (action === "viewInBrowser") handleViewInBrowserRef.current?.();
+    });
+    return unsub;
+  }, []);
+  useEffect(() => {
+    if (selected === null) {
+      setDetail(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setEditing(false);
+    const fetchDetail = async () => {
+      const args = [
+        "boards",
+        "work-item",
+        "show",
+        "--id",
+        String(selected),
+        "--output",
+        "json",
+        ...baseArgs(config)
+      ];
+      const r = await api.process.exec("az", args, { timeout: 3e4 });
+      if (cancelled) return;
+      if (r.exitCode === 0 && r.stdout.trim()) {
+        const raw = JSON.parse(r.stdout);
+        const parsed = parseWorkItemDetail(raw, config);
+        const comments = await fetchComments(api, config, parsed.id);
+        if (cancelled) return;
+        parsed.comments = comments;
+        setDetail(parsed);
+      } else {
+        setDetail(null);
+      }
+      setLoading(false);
+    };
+    fetchDetail().catch(() => {
+      if (!cancelled) {
+        setDetail(null);
+        setLoading(false);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [selected, api, detailVersion, config.organization, config.project]);
+  const refreshDetail = useCallback(() => setDetailVersion((v) => v + 1), []);
+  const startEditing = useCallback(() => {
+    if (!detail) return;
+    setEditTitle(detail.title);
+    setEditDescription(detail.description ? stripHtml(detail.description) : "");
+    setEditAssignedTo(detail.assignedTo);
+    setEditTags(detail.tags);
+    setEditing(true);
+  }, [detail]);
+  const saveEdit = useCallback(async () => {
+    if (!detail) return;
+    const args = [
+      "boards",
+      "work-item",
+      "update",
+      "--id",
+      String(detail.id),
+      "--output",
+      "json",
+      ...baseArgs(config)
+    ];
+    const fields = [];
+    if (editTitle.trim() !== detail.title) {
+      args.push("--title", editTitle.trim());
+    }
+    if (editDescription !== stripHtml(detail.description || "")) {
+      args.push("--description", editDescription);
+    }
+    if (editAssignedTo !== detail.assignedTo) {
+      if (editAssignedTo.trim()) {
+        fields.push(`System.AssignedTo=${editAssignedTo.trim()}`);
+      } else {
+        fields.push("System.AssignedTo=");
+      }
+    }
+    if (editTags !== detail.tags) {
+      fields.push(`System.Tags=${editTags}`);
+    }
+    if (fields.length > 0) {
+      args.push("--fields", ...fields);
+    }
+    const baseArgCount = 5 + baseArgs(config).length;
+    if (args.length <= baseArgCount + 2) {
+      setEditing(false);
+      return;
+    }
+    const r = await api.process.exec("az", args, { timeout: 3e4 });
+    if (r.exitCode === 0) {
+      api.ui.showNotice("Work item updated");
+      setEditing(false);
+      refreshDetail();
+      workItemState.requestRefresh();
+    } else {
+      api.ui.showError(r.stderr.trim() || "Failed to update work item");
+    }
+  }, [detail, editTitle, editDescription, editAssignedTo, editTags, api, config, refreshDetail]);
+  const handleAddComment = useCallback(async () => {
+    if (!detail || !commentBody.trim()) return;
+    const args = [
+      "boards",
+      "work-item",
+      "update",
+      "--id",
+      String(detail.id),
+      "--discussion",
+      commentBody.trim(),
+      "--output",
+      "json",
+      ...baseArgs(config)
+    ];
+    const r = await api.process.exec("az", args, { timeout: 3e4 });
+    if (r.exitCode === 0) {
+      api.ui.showNotice("Comment added");
+      setCommentBody("");
+      refreshDetail();
+    } else {
+      api.ui.showError(r.stderr.trim() || "Failed to add comment");
+    }
+  }, [detail, commentBody, api, config, refreshDetail]);
+  const handleToggleState = useCallback(() => {
+    if (!detail) return;
+    setShowStateDialog(true);
+  }, [detail]);
+  handleToggleStateRef.current = handleToggleState;
+  handleViewInBrowserRef.current = detail ? () => api.ui.openExternalUrl(detail.url) : null;
+  const handleCreate = useCallback(async () => {
+    if (!newTitle.trim()) return;
+    setCreating(true);
+    const args = [
+      "boards",
+      "work-item",
+      "create",
+      "--type",
+      newType,
+      "--title",
+      newTitle.trim(),
+      "--output",
+      "json",
+      ...baseArgs(config)
+    ];
+    if (newDescription.trim()) {
+      args.push("--description", newDescription.trim());
+    }
+    if (newAreaPath.trim()) {
+      args.push("--area", newAreaPath.trim());
+    }
+    if (newIterationPath.trim()) {
+      args.push("--iteration", newIterationPath.trim());
+    }
+    const fields = [];
+    if (newPriority) {
+      fields.push(`Microsoft.VSTS.Common.Priority=${newPriority}`);
+    }
+    if (newTags.trim()) {
+      fields.push(`System.Tags=${newTags.trim()}`);
+    }
+    if (fields.length > 0) {
+      args.push("--fields", ...fields);
+    }
+    const r = await api.process.exec("az", args, { timeout: 3e4 });
+    setCreating(false);
+    if (r.exitCode === 0) {
+      let createdId = "";
+      try {
+        const parsed = JSON.parse(r.stdout);
+        createdId = ` #${parsed.id}`;
+      } catch {
+      }
+      api.ui.showNotice(`Work item${createdId} created`);
+      setNewTitle("");
+      setNewDescription("");
+      setNewTags("");
+      setNewPriority("3");
+      workItemState.setCreatingNew(false);
+      workItemState.requestRefresh();
+    } else {
+      api.ui.showError(r.stderr.trim() || "Failed to create work item");
+    }
+  }, [newType, newTitle, newDescription, newAreaPath, newIterationPath, newPriority, newTags, api, config]);
+  const handleCancelCreate = useCallback(() => {
+    setNewTitle("");
+    setNewDescription("");
+    setNewTags("");
+    setNewPriority("3");
+    workItemState.setCreatingNew(false);
+  }, []);
+  if (creatingNew) {
+    return /* @__PURE__ */ jsxs("div", { style: mainContainer, children: [
+      /* @__PURE__ */ jsx("div", { style: mainHeader, children: /* @__PURE__ */ jsx("span", { style: { fontSize: "13px", fontWeight: 500, color: "var(--text-primary, #e0e0e0)" }, children: "New Work Item" }) }),
+      /* @__PURE__ */ jsx("div", { style: { flex: 1, overflowY: "auto", padding: "16px" }, children: /* @__PURE__ */ jsxs("div", { style: { display: "flex", flexDirection: "column", gap: "14px" }, children: [
+        /* @__PURE__ */ jsxs("div", { children: [
+          /* @__PURE__ */ jsx("label", { style: formLabel, children: "Type" }),
+          /* @__PURE__ */ jsxs(
+            "select",
+            {
+              value: newType,
+              onChange: (e) => setNewType(e.target.value),
+              style: formInput,
+              children: [
+                /* @__PURE__ */ jsx("option", { value: "Epic", children: "Epic" }),
+                /* @__PURE__ */ jsx("option", { value: "Feature", children: "Feature" }),
+                /* @__PURE__ */ jsx("option", { value: "User Story", children: "User Story" }),
+                /* @__PURE__ */ jsx("option", { value: "Product Backlog Item", children: "Product Backlog Item" }),
+                /* @__PURE__ */ jsx("option", { value: "Bug", children: "Bug" }),
+                /* @__PURE__ */ jsx("option", { value: "Task", children: "Task" }),
+                /* @__PURE__ */ jsx("option", { value: "Issue", children: "Issue" }),
+                /* @__PURE__ */ jsx("option", { value: "Impediment", children: "Impediment" })
+              ]
+            }
+          )
+        ] }),
+        /* @__PURE__ */ jsxs("div", { children: [
+          /* @__PURE__ */ jsx("label", { style: formLabel, children: "Title" }),
+          /* @__PURE__ */ jsx(
+            "input",
+            {
+              type: "text",
+              value: newTitle,
+              onChange: (e) => setNewTitle(e.target.value),
+              placeholder: "Work item title",
+              style: formInput,
+              autoFocus: true
+            }
+          )
+        ] }),
+        /* @__PURE__ */ jsxs("div", { children: [
+          /* @__PURE__ */ jsx("label", { style: formLabel, children: "Description" }),
+          /* @__PURE__ */ jsx(
+            "textarea",
+            {
+              value: newDescription,
+              onChange: (e) => setNewDescription(e.target.value),
+              placeholder: "Describe the work item\\u2026",
+              rows: 8,
+              style: { ...formInput, resize: "vertical" }
+            }
+          )
+        ] }),
+        /* @__PURE__ */ jsxs("div", { children: [
+          /* @__PURE__ */ jsx("label", { style: formLabel, children: "Area Path" }),
+          /* @__PURE__ */ jsx(
+            "input",
+            {
+              type: "text",
+              value: newAreaPath,
+              onChange: (e) => setNewAreaPath(e.target.value),
+              placeholder: config.areaPath || config.project,
+              style: formInput
+            }
+          )
+        ] }),
+        /* @__PURE__ */ jsxs("div", { children: [
+          /* @__PURE__ */ jsx("label", { style: formLabel, children: "Iteration Path" }),
+          /* @__PURE__ */ jsx(
+            "input",
+            {
+              type: "text",
+              value: newIterationPath,
+              onChange: (e) => setNewIterationPath(e.target.value),
+              placeholder: config.iterationPath || config.project,
+              style: formInput
+            }
+          )
+        ] }),
+        /* @__PURE__ */ jsxs("div", { children: [
+          /* @__PURE__ */ jsx("label", { style: formLabel, children: "Priority" }),
+          /* @__PURE__ */ jsxs(
+            "select",
+            {
+              value: newPriority,
+              onChange: (e) => setNewPriority(e.target.value),
+              style: formInput,
+              children: [
+                /* @__PURE__ */ jsx("option", { value: "1", children: "1 - Critical" }),
+                /* @__PURE__ */ jsx("option", { value: "2", children: "2 - High" }),
+                /* @__PURE__ */ jsx("option", { value: "3", children: "3 - Medium" }),
+                /* @__PURE__ */ jsx("option", { value: "4", children: "4 - Low" })
+              ]
+            }
+          )
+        ] }),
+        /* @__PURE__ */ jsxs("div", { children: [
+          /* @__PURE__ */ jsx("label", { style: formLabel, children: "Tags" }),
+          /* @__PURE__ */ jsx(
+            "input",
+            {
+              type: "text",
+              value: newTags,
+              onChange: (e) => setNewTags(e.target.value),
+              placeholder: "Tag1; Tag2; Tag3",
+              style: formInput
+            }
+          )
+        ] })
+      ] }) }),
+      /* @__PURE__ */ jsxs("div", { style: mainFooter, children: [
+        /* @__PURE__ */ jsx("button", { onClick: handleCancelCreate, disabled: creating, style: btnSecondarySmall, children: "Cancel" }),
+        /* @__PURE__ */ jsx(
+          "button",
+          {
+            onClick: handleCreate,
+            disabled: creating || !newTitle.trim(),
+            style: {
+              ...btnPrimarySmall,
+              opacity: creating || !newTitle.trim() ? 0.5 : 1
+            },
+            children: creating ? "Creating\u2026" : "Create Work Item"
+          }
+        )
+      ] })
+    ] });
+  }
+  if (selected === null) {
+    return /* @__PURE__ */ jsx("div", { style: { ...mainContainer, justifyContent: "center", alignItems: "center" }, children: /* @__PURE__ */ jsx("span", { style: { fontSize: "12px", color: "var(--text-secondary, #888)" }, children: "Select a work item to view details" }) });
+  }
+  if (loading) {
+    return /* @__PURE__ */ jsx("div", { style: { ...mainContainer, justifyContent: "center", alignItems: "center" }, children: /* @__PURE__ */ jsxs("span", { style: { fontSize: "12px", color: "var(--text-secondary, #888)" }, children: [
+      "Loading work item",
+      "\u2026"
+    ] }) });
+  }
+  if (!detail) {
+    return /* @__PURE__ */ jsx("div", { style: { ...mainContainer, justifyContent: "center", alignItems: "center" }, children: /* @__PURE__ */ jsx("span", { style: { fontSize: "12px", color: "var(--text-secondary, #888)" }, children: "Failed to load work item details" }) });
+  }
+  const sc = stateColor(detail.state);
+  const stateBadge = {
+    fontSize: "10px",
+    padding: "2px 8px",
+    borderRadius: "10px",
+    cursor: "pointer",
+    border: `1px solid ${sc.border}`,
+    background: sc.bg,
+    color: sc.fg
+  };
+  return /* @__PURE__ */ jsxs("div", { style: { ...mainContainer, position: "relative" }, children: [
+    /* @__PURE__ */ jsxs("div", { style: { ...mainHeader, gap: "8px" }, children: [
+      editing ? /* @__PURE__ */ jsx("div", { style: { flex: 1, minWidth: 0 }, children: /* @__PURE__ */ jsx(
+        "input",
+        {
+          type: "text",
+          value: editTitle,
+          onChange: (e) => setEditTitle(e.target.value),
+          style: { ...formInput, fontSize: "13px" }
+        }
+      ) }) : /* @__PURE__ */ jsxs("div", { style: { flex: 1, minWidth: 0, display: "flex", alignItems: "center", gap: "6px" }, children: [
+        /* @__PURE__ */ jsx(
+          "span",
+          {
+            style: {
+              width: "3px",
+              height: "16px",
+              borderRadius: "2px",
+              background: typeColor(detail.workItemType),
+              flexShrink: 0
+            }
+          }
+        ),
+        /* @__PURE__ */ jsxs("span", { style: { fontSize: "12px", color: "var(--text-secondary, #888)", flexShrink: 0 }, children: [
+          "#",
+          detail.id
+        ] }),
+        /* @__PURE__ */ jsx("span", { style: { fontSize: "13px", fontWeight: 500, color: "var(--text-primary, #e0e0e0)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }, children: detail.title })
+      ] }),
+      editing ? /* @__PURE__ */ jsxs(Fragment, { children: [
+        /* @__PURE__ */ jsx("button", { onClick: saveEdit, style: { ...btnPrimarySmall, flexShrink: 0 }, children: "Save" }),
+        /* @__PURE__ */ jsx("button", { onClick: () => setEditing(false), style: { ...btnSecondarySmall, flexShrink: 0 }, children: "Cancel" })
+      ] }) : /* @__PURE__ */ jsxs(Fragment, { children: [
+        /* @__PURE__ */ jsx("button", { onClick: startEditing, style: { ...btnSecondarySmall, flexShrink: 0 }, children: "Edit" }),
+        /* @__PURE__ */ jsx("button", { onClick: () => api.ui.openExternalUrl(detail.url), style: { ...btnSecondarySmall, flexShrink: 0 }, children: "View in Browser" }),
+        /* @__PURE__ */ jsx("button", { onClick: () => setShowAgentDialog(true), style: { ...btnPrimarySmall, flexShrink: 0 }, children: "Assign to Agent" })
+      ] })
+    ] }),
+    /* @__PURE__ */ jsxs("div", { style: { display: "flex", alignItems: "center", flexWrap: "wrap", gap: "6px", padding: "8px 16px", borderBottom: "1px solid var(--border-color, #222)", background: "var(--panel-bg-alt, rgba(0,0,0,0.15))" }, children: [
+      /* @__PURE__ */ jsx("button", { onClick: () => setShowStateDialog(true), style: stateBadge, title: "Change state", children: detail.state }),
+      /* @__PURE__ */ jsx("span", { style: { fontSize: "10px", color: typeColor(detail.workItemType), fontWeight: 500 }, children: detail.workItemType }),
+      detail.priority > 0 && /* @__PURE__ */ jsxs("span", { style: { fontSize: "10px", color: "var(--text-secondary, #888)" }, children: [
+        "P",
+        detail.priority,
+        " (",
+        priorityLabel(detail.priority),
+        ")"
+      ] }),
+      /* @__PURE__ */ jsxs("span", { style: { fontSize: "10px", color: "var(--text-secondary, #888)" }, children: [
+        "by ",
+        detail.createdBy
+      ] }),
+      /* @__PURE__ */ jsxs("span", { style: { fontSize: "10px", color: "var(--text-secondary, #888)" }, children: [
+        "created ",
+        relativeTime(detail.createdDate)
+      ] }),
+      editing ? /* @__PURE__ */ jsx(
+        "input",
+        {
+          type: "text",
+          value: editAssignedTo,
+          onChange: (e) => setEditAssignedTo(e.target.value),
+          placeholder: "Assigned to",
+          style: { fontSize: "10px", padding: "2px 6px", background: "var(--input-bg, #1a1a2e)", border: "1px solid var(--border-color, #333)", borderRadius: "4px", color: "var(--text-primary, #e0e0e0)", fontFamily: "var(--font-family)", outline: "none" }
+        }
+      ) : detail.assignedTo ? /* @__PURE__ */ jsx("span", { style: { fontSize: "10px", padding: "1px 6px", background: "var(--item-active-bg, #2a2a4a)", color: "var(--text-secondary, #aaa)", borderRadius: "4px" }, children: detail.assignedTo }) : null,
+      detail.areaPath && /* @__PURE__ */ jsxs("span", { style: { fontSize: "9px", color: "var(--text-secondary, #666)" }, children: [
+        "Area: ",
+        detail.areaPath
+      ] }),
+      detail.iterationPath && /* @__PURE__ */ jsxs("span", { style: { fontSize: "9px", color: "var(--text-secondary, #666)" }, children: [
+        "Iter: ",
+        detail.iterationPath
+      ] }),
+      editing ? /* @__PURE__ */ jsx(
+        "input",
+        {
+          type: "text",
+          value: editTags,
+          onChange: (e) => setEditTags(e.target.value),
+          placeholder: "Tags (semicolon separated)",
+          style: { fontSize: "10px", padding: "2px 6px", background: "var(--input-bg, #1a1a2e)", border: "1px solid var(--border-color, #333)", borderRadius: "4px", color: "var(--text-primary, #e0e0e0)", fontFamily: "var(--font-family)", outline: "none" }
+        }
+      ) : detail.tags ? detail.tags.split(";").map((tag) => tag.trim()).filter(Boolean).map((tag) => /* @__PURE__ */ jsx(
+        "span",
+        {
+          style: {
+            fontSize: "9px",
+            padding: "0 5px",
+            borderRadius: "10px",
+            backgroundColor: "rgba(100,100,200,0.15)",
+            color: "#8888cc",
+            border: "1px solid rgba(100,100,200,0.3)"
+          },
+          children: tag
+        },
+        tag
+      )) : null
+    ] }),
+    /* @__PURE__ */ jsxs("div", { style: { flex: 1, overflowY: "auto" }, children: [
+      editing ? /* @__PURE__ */ jsx("div", { style: { padding: "12px 16px", borderBottom: "1px solid var(--border-color, #222)" }, children: /* @__PURE__ */ jsx(
+        "textarea",
+        {
+          value: editDescription,
+          onChange: (e) => setEditDescription(e.target.value),
+          placeholder: "Work item description\\u2026",
+          rows: 10,
+          style: { ...formInput, resize: "vertical" }
+        }
+      ) }) : detail.description ? /* @__PURE__ */ jsx("div", { style: { padding: "12px 16px", borderBottom: "1px solid var(--border-color, #222)" }, children: /* @__PURE__ */ jsx("pre", { style: preStyle, children: stripHtml(detail.description) }) }) : /* @__PURE__ */ jsx("div", { style: { padding: "12px 16px", fontSize: "12px", color: "var(--text-secondary, #888)", fontStyle: "italic", borderBottom: "1px solid var(--border-color, #222)" }, children: "No description provided." }),
+      detail.comments.length > 0 && /* @__PURE__ */ jsxs("div", { style: { padding: "12px 16px", borderBottom: "1px solid var(--border-color, #222)" }, children: [
+        /* @__PURE__ */ jsxs("div", { style: { fontSize: "12px", fontWeight: 500, color: "var(--text-primary, #e0e0e0)", marginBottom: "12px" }, children: [
+          detail.comments.length,
+          " comment",
+          detail.comments.length === 1 ? "" : "s"
+        ] }),
+        /* @__PURE__ */ jsx("div", { style: { display: "flex", flexDirection: "column", gap: "10px" }, children: detail.comments.map((comment, i) => /* @__PURE__ */ jsxs(
+          "div",
+          {
+            style: {
+              border: "1px solid var(--border-color, #222)",
+              borderRadius: "6px",
+              overflow: "hidden"
+            },
+            children: [
+              /* @__PURE__ */ jsxs("div", { style: { display: "flex", alignItems: "center", gap: "8px", padding: "6px 10px", background: "var(--panel-bg-alt, rgba(0,0,0,0.15))", borderBottom: "1px solid var(--border-color, #222)" }, children: [
+                /* @__PURE__ */ jsx("span", { style: { fontSize: "12px", fontWeight: 500, color: "var(--text-primary, #e0e0e0)" }, children: comment.author }),
+                /* @__PURE__ */ jsx("span", { style: { fontSize: "10px", color: "var(--text-secondary, #888)" }, children: relativeTime(comment.createdDate) })
+              ] }),
+              /* @__PURE__ */ jsx("div", { style: { padding: "8px 10px" }, children: /* @__PURE__ */ jsx("pre", { style: preStyle, children: stripHtml(comment.body) }) })
+            ]
+          },
+          i
+        )) })
+      ] }),
+      /* @__PURE__ */ jsxs("div", { style: { padding: "12px 16px" }, children: [
+        /* @__PURE__ */ jsx("div", { style: { fontSize: "12px", fontWeight: 500, color: "var(--text-primary, #e0e0e0)", marginBottom: "8px" }, children: "Add a comment" }),
+        /* @__PURE__ */ jsx(
+          "textarea",
+          {
+            value: commentBody,
+            onChange: (e) => setCommentBody(e.target.value),
+            placeholder: "Write a comment\\u2026",
+            rows: 3,
+            style: { ...formInput, resize: "vertical" }
+          }
+        ),
+        /* @__PURE__ */ jsx("div", { style: { display: "flex", justifyContent: "flex-end", marginTop: "8px" }, children: /* @__PURE__ */ jsx(
+          "button",
+          {
+            onClick: handleAddComment,
+            disabled: !commentBody.trim(),
+            style: {
+              ...btnPrimarySmall,
+              opacity: commentBody.trim() ? 1 : 0.5
+            },
+            children: "Comment"
+          }
+        ) })
+      ] })
+    ] }),
+    showAgentDialog && detail && /* @__PURE__ */ jsx(
+      SendToAgentDialog,
+      {
+        api,
+        item: detail,
+        onClose: () => setShowAgentDialog(false)
+      }
+    ),
+    showStateDialog && detail && /* @__PURE__ */ jsx(
+      StatePickerDialog,
+      {
+        api,
+        item: detail,
+        config,
+        onClose: () => setShowStateDialog(false),
+        onStateChanged: () => {
+          refreshDetail();
+          workItemState.requestRefresh();
+        }
+      }
+    )
+  ] });
+}
+var sidebarContainer = {
+  display: "flex",
+  flexDirection: "column",
+  height: "100%",
+  fontFamily: "var(--font-family)",
+  background: "var(--sidebar-bg, #181825)"
+};
+var sidebarHeader = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  padding: "8px 10px",
+  borderBottom: "1px solid var(--border-color, #222)"
+};
+var sidebarHeaderBtn = {
+  padding: "2px 8px",
+  fontSize: "12px",
+  color: "var(--text-secondary, #888)",
+  background: "transparent",
+  border: "none",
+  borderRadius: "4px",
+  cursor: "pointer",
+  fontFamily: "var(--font-family)"
+};
+var mainContainer = {
+  display: "flex",
+  flexDirection: "column",
+  height: "100%",
+  fontFamily: "var(--font-family)",
+  background: "var(--panel-bg, #1e1e2e)"
+};
+var mainHeader = {
+  display: "flex",
+  alignItems: "center",
+  padding: "8px 16px",
+  borderBottom: "1px solid var(--border-color, #222)",
+  background: "var(--sidebar-bg, #181825)",
+  flexShrink: 0
+};
+var mainFooter = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "flex-end",
+  gap: "8px",
+  padding: "10px 16px",
+  borderTop: "1px solid var(--border-color, #222)",
+  background: "var(--sidebar-bg, #181825)",
+  flexShrink: 0
+};
+var formLabel = {
+  display: "block",
+  fontSize: "12px",
+  fontWeight: 500,
+  color: "var(--text-secondary, #aaa)",
+  marginBottom: "4px"
+};
+var formInput = {
+  width: "100%",
+  padding: "6px 10px",
+  borderRadius: "6px",
+  border: "1px solid var(--border-color, #333)",
+  background: "var(--input-bg, #1a1a2e)",
+  color: "var(--text-primary, #e0e0e0)",
+  fontSize: "13px",
+  fontFamily: "var(--font-family)",
+  boxSizing: "border-box",
+  outline: "none"
+};
+var filterSelect = {
+  padding: "4px 4px",
+  fontSize: "10px",
+  border: "1px solid var(--border-color, #333)",
+  borderRadius: "4px",
+  background: "var(--input-bg, #1a1a2e)",
+  color: "var(--text-primary, #e0e0e0)",
+  fontFamily: "var(--font-family)",
+  cursor: "pointer"
+};
+var preStyle = {
+  whiteSpace: "pre-wrap",
+  wordWrap: "break-word",
+  fontFamily: "var(--font-mono, monospace)",
+  fontSize: "13px",
+  lineHeight: 1.6,
+  color: "var(--text-primary, #e0e0e0)",
+  margin: 0
+};
+var btnPrimarySmall = {
+  padding: "4px 12px",
+  fontSize: "12px",
+  fontWeight: 500,
+  borderRadius: "4px",
+  border: "none",
+  background: "var(--accent-color, #4a6cf7)",
+  color: "#fff",
+  cursor: "pointer",
+  fontFamily: "var(--font-family)"
+};
+var btnSecondarySmall = {
+  padding: "4px 12px",
+  fontSize: "12px",
+  borderRadius: "4px",
+  border: "1px solid var(--border-color, #333)",
+  background: "transparent",
+  color: "var(--text-primary, #e0e0e0)",
+  cursor: "pointer",
+  fontFamily: "var(--font-family)"
+};
+export {
+  MainPanel,
+  SidebarPanel,
+  activate,
+  deactivate
+};

--- a/plugins/ado-work-items/manifest.json
+++ b/plugins/ado-work-items/manifest.json
@@ -1,0 +1,89 @@
+{
+  "id": "ado-work-items",
+  "name": "Azure DevOps Work Items",
+  "version": "0.1.0",
+  "description": "Browse, create, and manage Azure DevOps work items with WIQL query support and agent assignment",
+  "author": "Clubhouse Workshop",
+  "engine": { "api": 0.5 },
+  "scope": "project",
+  "main": "./dist/main.js",
+  "settingsPanel": "declarative",
+  "contributes": {
+    "tab": {
+      "label": "Work Items",
+      "icon": "<svg width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><rect x='3' y='3' width='18' height='18' rx='2'/><path d='M9 12l2 2 4-4'/></svg>",
+      "layout": "sidebar-content"
+    },
+    "commands": [
+      { "id": "ado-work-items.refresh", "title": "Refresh Work Items" },
+      { "id": "ado-work-items.create", "title": "Create Work Item" },
+      { "id": "ado-work-items.assignAgent", "title": "Assign Work Item to Agent" },
+      { "id": "ado-work-items.toggleState", "title": "Change Work Item State" },
+      { "id": "ado-work-items.viewInBrowser", "title": "View Work Item in Browser" }
+    ],
+    "settings": [
+      {
+        "key": "organization",
+        "type": "string",
+        "label": "Organization URL",
+        "description": "Azure DevOps organization URL (e.g., https://dev.azure.com/myorg)"
+      },
+      {
+        "key": "project",
+        "type": "string",
+        "label": "Project",
+        "description": "Azure DevOps project name"
+      },
+      {
+        "key": "team",
+        "type": "string",
+        "label": "Team (optional)",
+        "description": "Team name within the project (defaults to project default team)"
+      },
+      {
+        "key": "defaultWorkItemType",
+        "type": "string",
+        "label": "Default Work Item Type",
+        "description": "Default type when creating work items (e.g., User Story, Bug, Task)"
+      },
+      {
+        "key": "areaPath",
+        "type": "string",
+        "label": "Area Path (optional)",
+        "description": "Filter work items by area path (e.g., MyProject\\Frontend)"
+      },
+      {
+        "key": "iterationPath",
+        "type": "string",
+        "label": "Iteration Path (optional)",
+        "description": "Filter work items by iteration path (e.g., MyProject\\Sprint 1)"
+      },
+      {
+        "key": "queryPath",
+        "type": "string",
+        "label": "Saved Query Path (optional)",
+        "description": "Use a saved ADO query instead of the default listing (e.g., Shared Queries/Active Bugs)"
+      }
+    ],
+    "help": {
+      "topics": [
+        {
+          "id": "ado-work-items",
+          "title": "Azure DevOps Work Items",
+          "content": "## Azure DevOps Work Items\n\nThe Work Items tab lets you browse, create, edit, and manage Azure DevOps work items for the current project, with support for WIQL queries, saved queries, and agent assignment.\n\n### Requirements\n- The **Azure CLI** must be installed with the `azure-devops` extension (`az extension add --name azure-devops`)\n- You must be authenticated (`az login`)\n- Configure the **Organization URL** and **Project** in the plugin settings\n\n### Configuration\nOpen the plugin settings to configure:\n- **Organization URL** — Your ADO organization (e.g., `https://dev.azure.com/myorg`)\n- **Project** — The project name to query work items from\n- **Team** — Optional team name for iteration/area path scoping\n- **Default Work Item Type** — Type used when creating new items (e.g., User Story, Bug, Task)\n- **Area Path** — Optional filter to scope work items by area\n- **Iteration Path** — Optional filter to scope by sprint/iteration\n- **Saved Query Path** — Optional path to a saved ADO query (overrides default listing)\n\n### Browsing work items\nWork items are listed by most recently changed, 50 per page. Click a work item to view its full details in the main panel.\n\n- **State filter** — Use the dropdown to filter by state (e.g., New, Active, Closed)\n- **Type filter** — Filter by work item type (Bug, Task, User Story, etc.)\n- **Search** — Type in the filter box to instantly filter by title or ID\n\n### Work item detail view\nThe detail panel shows:\n- **Header** — Work item ID, title, and action buttons (Edit, View in Browser, Assign to Agent)\n- **Metadata** — State badge, type, assigned to, area path, iteration path, priority, tags\n- **Description** — Full work item description\n- **Discussion** — Comment history with author and timestamp\n- **Add comment** — Inline form to post a new discussion comment\n\n### Creating work items\nClick **+ New** in the sidebar or use the **Create Work Item** command. The creation form supports:\n- **Type selector** — Choose the work item type\n- **Title and Description** — Required title and optional description\n- **Area Path and Iteration Path** — Inherited from settings or overridden per item\n- **Priority** — 1 (Critical) through 4 (Low)\n- **Tags** — Comma-separated tags\n\n### Editing work items\nFrom the detail view, click **Edit** to modify the title, description, state, assigned to, and tags inline.\n\n### Assigning to agents\nFrom the detail view, click **Assign to Agent** to open a dialog listing your project's durable agents with status badges and optional additional instructions.\n\n### Commands\nAvailable from the command palette:\n- **Refresh Work Items** — Reloads the work item list\n- **Create Work Item** — Opens the work item creation form\n- **Assign Work Item to Agent** — Opens the agent assignment dialog for the selected work item\n- **Change Work Item State** — Advances the state of the selected work item\n- **View Work Item in Browser** — Opens the selected work item in the ADO web portal"
+        }
+      ]
+    }
+  },
+  "permissions": [
+    "logging",
+    "storage",
+    "notifications",
+    "agents",
+    "commands",
+    "process",
+    "settings",
+    "widgets"
+  ],
+  "allowedCommands": ["az"]
+}

--- a/plugins/ado-work-items/package.json
+++ b/plugins/ado-work-items/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "ado-work-items",
+  "version": "0.1.0",
+  "private": true,
+  "license": "MIT",
+  "description": "Azure DevOps Work Items plugin for Clubhouse with WIQL query support and agent assignment",
+  "scripts": {
+    "build": "esbuild src/main.tsx --bundle --format=esm --platform=browser --external:react --outfile=dist/main.js",
+    "watch": "esbuild src/main.tsx --bundle --format=esm --platform=browser --external:react --outfile=dist/main.js --watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@clubhouse/plugin-types": "file:../../sdk/plugin-types",
+    "@types/react": "^19.0.0",
+    "esbuild": "^0.24.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/plugins/ado-work-items/src/main.tsx
+++ b/plugins/ado-work-items/src/main.tsx
@@ -1,0 +1,2006 @@
+import type {
+  PluginContext,
+  PluginAPI,
+  PanelProps,
+  AgentInfo,
+} from "@clubhouse/plugin-types";
+
+const React = globalThis.React;
+const { useState, useEffect, useCallback, useRef, useMemo } = React;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface WorkItemListItem {
+  id: number;
+  title: string;
+  state: string;
+  workItemType: string;
+  assignedTo: string;
+  changedDate: string;
+  tags: string;
+  priority: number;
+  areaPath: string;
+  iterationPath: string;
+}
+
+interface WorkItemDetail extends WorkItemListItem {
+  description: string;
+  url: string;
+  createdBy: string;
+  createdDate: string;
+  reason: string;
+  comments: Array<{ author: string; body: string; createdDate: string }>;
+}
+
+interface AdoConfig {
+  organization: string;
+  project: string;
+  team: string;
+  defaultWorkItemType: string;
+  areaPath: string;
+  iterationPath: string;
+  queryPath: string;
+}
+
+// ---------------------------------------------------------------------------
+// Shared state (coordinates SidebarPanel and MainPanel across React trees)
+// ---------------------------------------------------------------------------
+
+const workItemState = {
+  selectedId: null as number | null,
+  creatingNew: false,
+  items: [] as WorkItemListItem[],
+  loading: false,
+  needsRefresh: false,
+  stateFilter: "" as string,
+  typeFilter: "" as string,
+  searchQuery: "",
+  listeners: new Set<() => void>(),
+
+  setSelectedItem(id: number | null): void {
+    this.selectedId = id;
+    this.creatingNew = false;
+    this.notify();
+  },
+
+  setCreatingNew(val: boolean): void {
+    this.creatingNew = val;
+    if (val) this.selectedId = null;
+    this.notify();
+  },
+
+  setItems(items: WorkItemListItem[]): void {
+    this.items = items;
+    this.notify();
+  },
+
+  setLoading(loading: boolean): void {
+    this.loading = loading;
+    this.notify();
+  },
+
+  setStateFilter(filter: string): void {
+    this.stateFilter = filter;
+    this.requestRefresh();
+  },
+
+  setTypeFilter(filter: string): void {
+    this.typeFilter = filter;
+    this.requestRefresh();
+  },
+
+  setSearchQuery(query: string): void {
+    this.searchQuery = query;
+    this.notify();
+  },
+
+  pendingAction: null as "assignAgent" | "toggleState" | "viewInBrowser" | null,
+
+  triggerAction(action: "assignAgent" | "toggleState" | "viewInBrowser"): void {
+    if (this.selectedId === null) return;
+    this.pendingAction = action;
+    this.notify();
+  },
+
+  consumeAction(): "assignAgent" | "toggleState" | "viewInBrowser" | null {
+    const action = this.pendingAction;
+    this.pendingAction = null;
+    return action;
+  },
+
+  requestRefresh(): void {
+    this.needsRefresh = true;
+    this.notify();
+  },
+
+  subscribe(fn: () => void): () => void {
+    this.listeners.add(fn);
+    return () => {
+      this.listeners.delete(fn);
+    };
+  },
+
+  notify(): void {
+    for (const fn of this.listeners) fn();
+  },
+
+  reset(): void {
+    this.selectedId = null;
+    this.creatingNew = false;
+    this.items = [];
+    this.loading = false;
+    this.needsRefresh = false;
+    this.pendingAction = null;
+    this.stateFilter = "";
+    this.typeFilter = "";
+    this.searchQuery = "";
+    this.listeners.clear();
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function relativeTime(dateStr: string): string {
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  const diffMs = now - then;
+  const diffMin = Math.floor(diffMs / 60000);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffH = Math.floor(diffMin / 60);
+  if (diffH < 24) return `${diffH}h ago`;
+  const diffD = Math.floor(diffH / 24);
+  if (diffD < 30) return `${diffD}d ago`;
+  const diffMo = Math.floor(diffD / 30);
+  return `${diffMo}mo ago`;
+}
+
+function getConfig(api: PluginAPI): AdoConfig {
+  return {
+    organization: (api.settings.get<string>("organization") || "").replace(/\/+$/, ""),
+    project: api.settings.get<string>("project") || "",
+    team: api.settings.get<string>("team") || "",
+    defaultWorkItemType: api.settings.get<string>("defaultWorkItemType") || "Task",
+    areaPath: api.settings.get<string>("areaPath") || "",
+    iterationPath: api.settings.get<string>("iterationPath") || "",
+    queryPath: api.settings.get<string>("queryPath") || "",
+  };
+}
+
+function baseArgs(config: AdoConfig): string[] {
+  const args: string[] = [];
+  if (config.organization) args.push("--org", config.organization);
+  if (config.project) args.push("--project", config.project);
+  return args;
+}
+
+function typeColor(type: string): string {
+  switch (type.toLowerCase()) {
+    case "bug": return "#cc293d";
+    case "task": return "#f2cb1d";
+    case "user story": return "#009ccc";
+    case "product backlog item": return "#009ccc";
+    case "feature": return "#773b93";
+    case "epic": return "#ff7b00";
+    case "issue": return "#009ccc";
+    case "impediment": return "#cc293d";
+    default: return "#888";
+  }
+}
+
+function stateColor(state: string): { bg: string; fg: string; border: string } {
+  const s = state.toLowerCase();
+  if (s === "new" || s === "to do" || s === "proposed")
+    return { bg: "rgba(180,180,180,0.1)", fg: "#b4b4b4", border: "rgba(180,180,180,0.3)" };
+  if (s === "active" || s === "in progress" || s === "committed" || s === "doing")
+    return { bg: "rgba(0,122,204,0.1)", fg: "#007acc", border: "rgba(0,122,204,0.3)" };
+  if (s === "resolved" || s === "done")
+    return { bg: "rgba(64,200,100,0.1)", fg: "#4ade80", border: "rgba(64,200,100,0.3)" };
+  if (s === "closed" || s === "removed")
+    return { bg: "rgba(168,85,247,0.1)", fg: "#c084fc", border: "rgba(168,85,247,0.3)" };
+  return { bg: "rgba(180,180,180,0.1)", fg: "#b4b4b4", border: "rgba(180,180,180,0.3)" };
+}
+
+function priorityLabel(p: number): string {
+  switch (p) {
+    case 1: return "Critical";
+    case 2: return "High";
+    case 3: return "Medium";
+    case 4: return "Low";
+    default: return "";
+  }
+}
+
+function buildWorkItemUrl(config: AdoConfig, id: number): string {
+  return `${config.organization}/${encodeURIComponent(config.project)}/_workitems/edit/${id}`;
+}
+
+/** Parse the output of `az boards work-item show` into our detail type. */
+function parseWorkItemDetail(raw: Record<string, unknown>, config: AdoConfig): WorkItemDetail {
+  const fields = raw.fields as Record<string, unknown> | undefined;
+  if (!fields) {
+    return {
+      id: (raw.id as number) || 0,
+      title: "",
+      state: "",
+      workItemType: "",
+      assignedTo: "",
+      changedDate: "",
+      tags: "",
+      priority: 0,
+      areaPath: "",
+      iterationPath: "",
+      description: "",
+      url: "",
+      createdBy: "",
+      createdDate: "",
+      reason: "",
+      comments: [],
+    };
+  }
+  const assignedToField = fields["System.AssignedTo"];
+  const assignedTo = typeof assignedToField === "object" && assignedToField !== null
+    ? (assignedToField as Record<string, string>).displayName || (assignedToField as Record<string, string>).uniqueName || ""
+    : typeof assignedToField === "string" ? assignedToField : "";
+  const createdByField = fields["System.CreatedBy"];
+  const createdBy = typeof createdByField === "object" && createdByField !== null
+    ? (createdByField as Record<string, string>).displayName || (createdByField as Record<string, string>).uniqueName || ""
+    : typeof createdByField === "string" ? createdByField : "";
+
+  return {
+    id: (raw.id as number) || 0,
+    title: (fields["System.Title"] as string) || "",
+    state: (fields["System.State"] as string) || "",
+    workItemType: (fields["System.WorkItemType"] as string) || "",
+    assignedTo,
+    changedDate: (fields["System.ChangedDate"] as string) || "",
+    tags: (fields["System.Tags"] as string) || "",
+    priority: (fields["Microsoft.VSTS.Common.Priority"] as number) || 0,
+    areaPath: (fields["System.AreaPath"] as string) || "",
+    iterationPath: (fields["System.IterationPath"] as string) || "",
+    description: (fields["System.Description"] as string) || "",
+    url: buildWorkItemUrl(config, (raw.id as number) || 0),
+    createdBy,
+    createdDate: (fields["System.CreatedDate"] as string) || "",
+    reason: (fields["System.Reason"] as string) || "",
+    comments: [],
+  };
+}
+
+/** Parse WIQL query results (list of IDs) and fetch work item details. */
+async function fetchWorkItemsByIds(
+  api: PluginAPI,
+  config: AdoConfig,
+  ids: number[],
+): Promise<WorkItemListItem[]> {
+  if (ids.length === 0) return [];
+
+  // az boards work-item show supports single ID; batch via comma-separated IDs
+  const batchSize = 50;
+  const results: WorkItemListItem[] = [];
+
+  for (let i = 0; i < ids.length; i += batchSize) {
+    const batch = ids.slice(i, i + batchSize);
+    const args = [
+      "boards", "work-item", "show",
+      "--id", batch.join(","),
+      "--output", "json",
+      ...baseArgs(config),
+    ];
+    const r = await api.process.exec("az", args, { timeout: 30000 });
+    if (r.exitCode !== 0 || !r.stdout.trim()) continue;
+
+    const parsed = JSON.parse(r.stdout);
+    // Single ID returns object, multiple returns array
+    const items: Record<string, unknown>[] = Array.isArray(parsed) ? parsed : [parsed];
+
+    for (const raw of items) {
+      const fields = raw.fields as Record<string, unknown> | undefined;
+      if (!fields) continue;
+      const assignedToField = fields["System.AssignedTo"];
+      const assignedTo = typeof assignedToField === "object" && assignedToField !== null
+        ? (assignedToField as Record<string, string>).displayName || ""
+        : typeof assignedToField === "string" ? assignedToField : "";
+
+      results.push({
+        id: (raw.id as number) || 0,
+        title: (fields["System.Title"] as string) || "",
+        state: (fields["System.State"] as string) || "",
+        workItemType: (fields["System.WorkItemType"] as string) || "",
+        assignedTo,
+        changedDate: (fields["System.ChangedDate"] as string) || "",
+        tags: (fields["System.Tags"] as string) || "",
+        priority: (fields["Microsoft.VSTS.Common.Priority"] as number) || 0,
+        areaPath: (fields["System.AreaPath"] as string) || "",
+        iterationPath: (fields["System.IterationPath"] as string) || "",
+      });
+    }
+  }
+
+  return results;
+}
+
+/** Fetch work item comments using az devops CLI. */
+async function fetchComments(
+  api: PluginAPI,
+  config: AdoConfig,
+  workItemId: number,
+): Promise<Array<{ author: string; body: string; createdDate: string }>> {
+  // The az CLI doesn't have a direct comments command for work items.
+  // Work item history/discussion is accessed via System.History field on updates.
+  // We use the REST API via `az rest` to get comments.
+  const url = `${config.organization}/${encodeURIComponent(config.project)}/_apis/wit/workItems/${workItemId}/comments?api-version=7.1-preview.4`;
+  const r = await api.process.exec("az", ["rest", "--method", "get", "--url", url, "--output", "json"], { timeout: 30000 });
+  if (r.exitCode !== 0 || !r.stdout.trim()) return [];
+  try {
+    const data = JSON.parse(r.stdout);
+    const comments: Array<{ author: string; body: string; createdDate: string }> = [];
+    if (data.comments && Array.isArray(data.comments)) {
+      for (const c of data.comments) {
+        comments.push({
+          author: c.createdBy?.displayName || c.createdBy?.uniqueName || "Unknown",
+          body: c.text || "",
+          createdDate: c.createdDate || "",
+        });
+      }
+    }
+    return comments;
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+let pluginApi: PluginAPI | null = null;
+
+export function activate(ctx: PluginContext, api: PluginAPI): void {
+  pluginApi = api;
+  api.logging.info("Azure DevOps Work Items activated");
+
+  ctx.subscriptions.push(
+    api.commands.register("ado-work-items.refresh", () => {
+      workItemState.requestRefresh();
+    }),
+  );
+  ctx.subscriptions.push(
+    api.commands.register("ado-work-items.create", () => {
+      workItemState.setCreatingNew(true);
+    }),
+  );
+  ctx.subscriptions.push(
+    api.commands.register("ado-work-items.assignAgent", () => {
+      if (!workItemState.selectedId) {
+        api.ui.showError("Select a work item first");
+        return;
+      }
+      workItemState.triggerAction("assignAgent");
+    }),
+  );
+  ctx.subscriptions.push(
+    api.commands.register("ado-work-items.toggleState", () => {
+      if (!workItemState.selectedId) {
+        api.ui.showError("Select a work item first");
+        return;
+      }
+      workItemState.triggerAction("toggleState");
+    }),
+  );
+  ctx.subscriptions.push(
+    api.commands.register("ado-work-items.viewInBrowser", () => {
+      if (!workItemState.selectedId) {
+        api.ui.showError("Select a work item first");
+        return;
+      }
+      workItemState.triggerAction("viewInBrowser");
+    }),
+  );
+}
+
+export function deactivate(): void {
+  pluginApi = null;
+  workItemState.reset();
+}
+
+// ---------------------------------------------------------------------------
+// SendToAgentDialog
+// ---------------------------------------------------------------------------
+
+function buildAgentPrompt(item: WorkItemDetail): string {
+  const tags = item.tags ? `Tags: ${item.tags}` : "";
+  return [
+    "Review and work on the following Azure DevOps work item:",
+    "",
+    `Work Item #${item.id}: ${item.title}`,
+    `Type: ${item.workItemType}`,
+    `State: ${item.state}`,
+    `Priority: ${priorityLabel(item.priority) || String(item.priority)}`,
+    item.assignedTo ? `Assigned To: ${item.assignedTo}` : "",
+    item.areaPath ? `Area: ${item.areaPath}` : "",
+    item.iterationPath ? `Iteration: ${item.iterationPath}` : "",
+    tags,
+    "",
+    item.description ? stripHtml(item.description) : "(no description)",
+  ].filter(Boolean).join("\n");
+}
+
+/** Strip HTML tags for plain-text display. */
+function stripHtml(html: string): string {
+  return html
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/p>/gi, "\n")
+    .replace(/<\/div>/gi, "\n")
+    .replace(/<\/li>/gi, "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function statusBadgeStyle(status: AgentInfo["status"]): React.CSSProperties {
+  const base: React.CSSProperties = {
+    fontSize: "9px",
+    padding: "1px 4px",
+    borderRadius: "3px",
+    display: "inline-block",
+  };
+  switch (status) {
+    case "sleeping":
+      return { ...base, background: "rgba(64,200,100,0.15)", color: "#4ade80" };
+    case "running":
+      return { ...base, background: "rgba(234,179,8,0.15)", color: "#facc15" };
+    case "error":
+      return { ...base, background: "rgba(239,68,68,0.15)", color: "#f87171" };
+    default:
+      return base;
+  }
+}
+
+function SendToAgentDialog({
+  api,
+  item,
+  onClose,
+}: {
+  api: PluginAPI;
+  item: WorkItemDetail;
+  onClose: () => void;
+}) {
+  const [instructions, setInstructions] = useState("");
+  const [saveAsDefault, setSaveAsDefault] = useState(false);
+  const [durableAgents, setDurableAgents] = useState<AgentInfo[]>([]);
+  const [defaultLoaded, setDefaultLoaded] = useState(false);
+  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  const AgentAvatar = api.widgets.AgentAvatar;
+
+  useEffect(() => {
+    const agents = api.agents.list().filter(a => a.kind === "durable");
+    setDurableAgents(agents);
+
+    api.storage.projectLocal.read("defaultAgentInstructions").then(saved => {
+      if (typeof saved === "string" && saved.length > 0) {
+        setInstructions(saved);
+      }
+      setDefaultLoaded(true);
+    }).catch(() => {
+      setDefaultLoaded(true);
+    });
+  }, [api]);
+
+  useEffect(() => {
+    const handleMouseDown = (e: MouseEvent) => {
+      if (overlayRef.current && e.target === overlayRef.current) onClose();
+    };
+    document.addEventListener("mousedown", handleMouseDown);
+    return () => document.removeEventListener("mousedown", handleMouseDown);
+  }, [onClose]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  const buildMission = useCallback((): string => {
+    const ctx = buildAgentPrompt(item);
+    if (instructions.trim()) return `${ctx}\n\nAdditional instructions:\n${instructions.trim()}`;
+    return ctx;
+  }, [item, instructions]);
+
+  const persistDefault = useCallback(async () => {
+    if (saveAsDefault && instructions.trim()) {
+      await api.storage.projectLocal.write("defaultAgentInstructions", instructions.trim());
+    }
+  }, [api, saveAsDefault, instructions]);
+
+  const handleConfirm = useCallback(async () => {
+    const agent = durableAgents.find(a => a.id === selectedAgentId);
+    if (!agent) return;
+
+    if (agent.status === "running") {
+      const ok = await api.ui.showConfirm(
+        `"${agent.name}" is currently running. Assigning this work item will interrupt its current work. Continue?`,
+      );
+      if (!ok) return;
+      await api.agents.kill(agent.id);
+    }
+
+    const mission = buildMission();
+    try {
+      await persistDefault();
+      await api.agents.resume(agent.id, { mission });
+      api.ui.showNotice(`Agent "${agent.name}" assigned to work item #${item.id}`);
+    } catch {
+      api.ui.showError(`Failed to assign agent to work item #${item.id}`);
+    }
+    onClose();
+  }, [durableAgents, selectedAgentId, api, item, buildMission, persistDefault, onClose]);
+
+  return (
+    <div
+      ref={overlayRef}
+      style={{
+        position: "absolute",
+        inset: 0,
+        zIndex: 50,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "rgba(0,0,0,0.5)",
+      }}
+    >
+      <div
+        style={{
+          background: "var(--panel-bg, #1e1e2e)",
+          border: "1px solid var(--border-color, #333)",
+          borderRadius: "8px",
+          padding: "16px",
+          width: "320px",
+          maxHeight: "80vh",
+          overflow: "auto",
+          boxShadow: "0 8px 32px rgba(0,0,0,0.4)",
+        }}
+      >
+        <div style={{ fontSize: "14px", fontWeight: 500, color: "var(--text-primary, #e0e0e0)", marginBottom: "4px" }}>
+          Assign to Agent
+        </div>
+        <div style={{ fontSize: "10px", color: "var(--text-secondary, #888)", marginBottom: "12px", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+          #{item.id} {item.title}
+        </div>
+
+        <textarea
+          value={instructions}
+          onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+            setInstructions((e.target as HTMLTextAreaElement).value)
+          }
+          placeholder="Additional instructions (optional)"
+          rows={3}
+          autoFocus
+          style={{
+            width: "100%",
+            padding: "6px 8px",
+            fontSize: "12px",
+            background: "var(--input-bg, #1a1a2e)",
+            border: "1px solid var(--border-color, #333)",
+            borderRadius: "4px",
+            color: "var(--text-primary, #e0e0e0)",
+            resize: "none",
+            fontFamily: "var(--font-family)",
+            boxSizing: "border-box",
+          }}
+        />
+
+        <div style={{ marginTop: "12px", display: "flex", flexDirection: "column", gap: "4px" }}>
+          {durableAgents.length === 0 ? (
+            <div style={{ fontSize: "12px", color: "var(--text-secondary, #888)", textAlign: "center", padding: "16px 0" }}>
+              No durable agents found
+            </div>
+          ) : (
+            durableAgents.map(agent => {
+              const isSelected = selectedAgentId === agent.id;
+              return (
+                <button
+                  key={agent.id}
+                  onClick={() => setSelectedAgentId(prev => prev === agent.id ? null : agent.id)}
+                  style={{
+                    width: "100%",
+                    textAlign: "left",
+                    padding: "8px 10px",
+                    fontSize: "12px",
+                    color: "var(--text-primary, #e0e0e0)",
+                    borderRadius: "4px",
+                    border: isSelected ? "1px solid var(--accent-color, #4a6cf7)" : "1px solid transparent",
+                    background: isSelected ? "rgba(74,108,247,0.1)" : "transparent",
+                    cursor: "pointer",
+                    fontFamily: "var(--font-family)",
+                  }}
+                >
+                  <div style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+                    <AgentAvatar agentId={agent.id} size="sm" showStatusRing />
+                    <span style={{ fontWeight: 500 }}>{agent.name}</span>
+                    <span style={statusBadgeStyle(agent.status)}>{agent.status}</span>
+                  </div>
+                  <div style={{ fontSize: "10px", color: "var(--text-secondary, #888)", marginTop: "2px", paddingLeft: "22px" }}>
+                    {agent.status === "running" ? "Will interrupt current work" : "Assign work item to this agent"}
+                  </div>
+                </button>
+              );
+            })
+          )}
+        </div>
+
+        <div
+          style={{
+            marginTop: "12px",
+            paddingTop: "12px",
+            borderTop: "1px solid var(--border-color, #333)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
+          {defaultLoaded && (
+            <label
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: "6px",
+                cursor: "pointer",
+                userSelect: "none",
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={saveAsDefault}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setSaveAsDefault((e.target as HTMLInputElement).checked)
+                }
+              />
+              <span style={{ fontSize: "10px", color: "var(--text-secondary, #888)" }}>
+                Save as default
+              </span>
+            </label>
+          )}
+          <div style={{ display: "flex", gap: "6px", marginLeft: "auto" }}>
+            <button onClick={onClose} style={btnSecondarySmall}>
+              Cancel
+            </button>
+            <button
+              onClick={handleConfirm}
+              disabled={!selectedAgentId}
+              style={{
+                ...btnPrimarySmall,
+                opacity: selectedAgentId ? 1 : 0.4,
+                cursor: selectedAgentId ? "pointer" : "default",
+              }}
+            >
+              Confirm
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// StatePickerDialog — lets user pick the next state for a work item
+// ---------------------------------------------------------------------------
+
+function StatePickerDialog({
+  api,
+  item,
+  config,
+  onClose,
+  onStateChanged,
+}: {
+  api: PluginAPI;
+  item: WorkItemDetail;
+  config: AdoConfig;
+  onClose: () => void;
+  onStateChanged: () => void;
+}) {
+  const [states, setStates] = useState<string[]>([]);
+  const [loadingStates, setLoadingStates] = useState(true);
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // Determine available states based on work item type
+    // Common states across process templates
+    const commonStates: Record<string, string[]> = {
+      "bug": ["New", "Active", "Resolved", "Closed"],
+      "task": ["New", "Active", "Closed"],
+      "user story": ["New", "Active", "Resolved", "Closed"],
+      "product backlog item": ["New", "Approved", "Committed", "Done"],
+      "feature": ["New", "Active", "Resolved", "Closed"],
+      "epic": ["New", "Active", "Resolved", "Closed"],
+      "issue": ["To Do", "Doing", "Done"],
+      "impediment": ["Open", "Closed"],
+    };
+    const key = item.workItemType.toLowerCase();
+    const available = commonStates[key] || ["New", "Active", "Resolved", "Closed"];
+    setStates(available.filter(s => s !== item.state));
+    setLoadingStates(false);
+  }, [item]);
+
+  useEffect(() => {
+    const handleMouseDown = (e: MouseEvent) => {
+      if (overlayRef.current && e.target === overlayRef.current) onClose();
+    };
+    document.addEventListener("mousedown", handleMouseDown);
+    return () => document.removeEventListener("mousedown", handleMouseDown);
+  }, [onClose]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose]);
+
+  const handleSelectState = useCallback(async (newState: string) => {
+    const args = [
+      "boards", "work-item", "update",
+      "--id", String(item.id),
+      "--state", newState,
+      "--output", "json",
+      ...baseArgs(config),
+    ];
+    const r = await api.process.exec("az", args, { timeout: 30000 });
+    if (r.exitCode === 0) {
+      api.ui.showNotice(`Work item #${item.id} moved to "${newState}"`);
+      onStateChanged();
+    } else {
+      api.ui.showError(r.stderr.trim() || `Failed to change state to "${newState}"`);
+    }
+    onClose();
+  }, [item, config, api, onClose, onStateChanged]);
+
+  return (
+    <div
+      ref={overlayRef}
+      style={{
+        position: "absolute",
+        inset: 0,
+        zIndex: 50,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "rgba(0,0,0,0.5)",
+      }}
+    >
+      <div
+        style={{
+          background: "var(--panel-bg, #1e1e2e)",
+          border: "1px solid var(--border-color, #333)",
+          borderRadius: "8px",
+          padding: "16px",
+          width: "260px",
+          boxShadow: "0 8px 32px rgba(0,0,0,0.4)",
+        }}
+      >
+        <div style={{ fontSize: "14px", fontWeight: 500, color: "var(--text-primary, #e0e0e0)", marginBottom: "4px" }}>
+          Change State
+        </div>
+        <div style={{ fontSize: "10px", color: "var(--text-secondary, #888)", marginBottom: "12px" }}>
+          Current: {item.state}
+        </div>
+
+        {loadingStates ? (
+          <div style={{ fontSize: "12px", color: "var(--text-secondary, #888)", textAlign: "center", padding: "8px" }}>
+            Loading{"\u2026"}
+          </div>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+            {states.map(s => {
+              const colors = stateColor(s);
+              return (
+                <button
+                  key={s}
+                  onClick={() => handleSelectState(s)}
+                  style={{
+                    width: "100%",
+                    textAlign: "left",
+                    padding: "6px 10px",
+                    fontSize: "12px",
+                    color: colors.fg,
+                    borderRadius: "4px",
+                    border: `1px solid ${colors.border}`,
+                    background: colors.bg,
+                    cursor: "pointer",
+                    fontFamily: "var(--font-family)",
+                  }}
+                >
+                  {s}
+                </button>
+              );
+            })}
+          </div>
+        )}
+
+        <div style={{ marginTop: "12px", display: "flex", justifyContent: "flex-end" }}>
+          <button onClick={onClose} style={btnSecondarySmall}>Cancel</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ConfigWarning — shown when org/project not configured
+// ---------------------------------------------------------------------------
+
+function ConfigWarning() {
+  return (
+    <div style={{ ...sidebarContainer, justifyContent: "center", alignItems: "center" }}>
+      <div style={{ padding: "16px", textAlign: "center" }}>
+        <div style={{ fontSize: "12px", color: "var(--text-error, #f87171)", marginBottom: "8px" }}>
+          Plugin not configured
+        </div>
+        <div style={{ fontSize: "11px", color: "var(--text-secondary, #888)", marginBottom: "12px", lineHeight: 1.5 }}>
+          Open the plugin settings and configure your Azure DevOps Organization URL and Project name.
+          The Azure CLI must also be installed with the azure-devops extension.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SidebarPanel
+// ---------------------------------------------------------------------------
+
+export function SidebarPanel({ api }: PanelProps) {
+  const [items, setItems] = useState<WorkItemListItem[]>(workItemState.items);
+  const [selected, setSelected] = useState<number | null>(workItemState.selectedId);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [needsRefresh, setNeedsRefresh] = useState(false);
+  const [stateFilter, setStateFilter] = useState(workItemState.stateFilter);
+  const [typeFilter, setTypeFilter] = useState(workItemState.typeFilter);
+  const [searchQuery, setSearchQuery] = useState(workItemState.searchQuery);
+  const mountedRef = useRef(true);
+
+  const config = getConfig(api);
+
+  // Subscribe to shared state
+  useEffect(() => {
+    mountedRef.current = true;
+    const unsub = workItemState.subscribe(() => {
+      if (!mountedRef.current) return;
+      setItems([...workItemState.items]);
+      setSelected(workItemState.selectedId);
+      setLoading(workItemState.loading);
+      setNeedsRefresh(workItemState.needsRefresh);
+      setStateFilter(workItemState.stateFilter);
+      setTypeFilter(workItemState.typeFilter);
+      setSearchQuery(workItemState.searchQuery);
+    });
+    return () => { mountedRef.current = false; unsub(); };
+  }, []);
+
+  // Fetch work items
+  const fetchItems = useCallback(async () => {
+    if (!config.organization || !config.project) return;
+
+    workItemState.setLoading(true);
+    setError(null);
+    try {
+      let ids: number[] = [];
+
+      if (config.queryPath) {
+        // Use saved query
+        const args = [
+          "boards", "query",
+          "--path", config.queryPath,
+          "--output", "json",
+          ...baseArgs(config),
+        ];
+        const r = await api.process.exec("az", args, { timeout: 30000 });
+        if (!mountedRef.current) return;
+        if (r.exitCode !== 0 || !r.stdout.trim()) {
+          setError("Failed to execute saved query. Check the query path in settings.");
+          workItemState.setLoading(false);
+          return;
+        }
+        const parsed = JSON.parse(r.stdout);
+        ids = (parsed as Array<Record<string, unknown>>).map(
+          (wi) => (wi.id as number) || 0,
+        ).filter(Boolean);
+      } else {
+        // Build WIQL query
+        const conditions: string[] = [
+          `[System.TeamProject] = '${config.project}'`,
+        ];
+        if (workItemState.stateFilter) {
+          conditions.push(`[System.State] = '${workItemState.stateFilter}'`);
+        }
+        if (workItemState.typeFilter) {
+          conditions.push(`[System.WorkItemType] = '${workItemState.typeFilter}'`);
+        }
+        if (config.areaPath) {
+          conditions.push(`[System.AreaPath] UNDER '${config.areaPath}'`);
+        }
+        if (config.iterationPath) {
+          conditions.push(`[System.IterationPath] UNDER '${config.iterationPath}'`);
+        }
+
+        const wiql = `SELECT [System.Id] FROM WorkItems WHERE ${conditions.join(" AND ")} ORDER BY [System.ChangedDate] DESC`;
+
+        const args = [
+          "boards", "query",
+          "--wiql", wiql,
+          "--output", "json",
+          ...baseArgs(config),
+        ];
+        const r = await api.process.exec("az", args, { timeout: 30000 });
+        if (!mountedRef.current) return;
+        if (r.exitCode !== 0 || !r.stdout.trim()) {
+          setError("Failed to query work items. Is the Azure CLI installed and authenticated?");
+          workItemState.setLoading(false);
+          return;
+        }
+        const parsed = JSON.parse(r.stdout);
+        ids = (parsed as Array<Record<string, unknown>>).map(
+          (wi) => (wi.id as number) || 0,
+        ).filter(Boolean);
+      }
+
+      // Limit to 50 for performance
+      ids = ids.slice(0, 50);
+
+      if (ids.length === 0) {
+        workItemState.setItems([]);
+        workItemState.setLoading(false);
+        return;
+      }
+
+      const results = await fetchWorkItemsByIds(api, config, ids);
+      if (!mountedRef.current) return;
+      workItemState.setItems(results);
+    } catch {
+      if (!mountedRef.current) return;
+      setError("Failed to load work items. Is the Azure CLI installed and authenticated?");
+    } finally {
+      workItemState.setLoading(false);
+    }
+  }, [api, config.organization, config.project, config.areaPath, config.iterationPath, config.queryPath]);
+
+  // Initial fetch
+  useEffect(() => {
+    if (workItemState.items.length === 0 && config.organization && config.project) {
+      fetchItems();
+    }
+  }, [fetchItems]);
+
+  // React to refresh requests
+  useEffect(() => {
+    if (needsRefresh) {
+      workItemState.needsRefresh = false;
+      fetchItems();
+    }
+  }, [needsRefresh, fetchItems]);
+
+  // Re-fetch on settings change
+  useEffect(() => {
+    const unsub = api.settings.onChange(() => {
+      workItemState.requestRefresh();
+    });
+    return () => unsub.dispose();
+  }, [api]);
+
+  // Filter items by search query (client-side)
+  const filteredItems = useMemo(() => {
+    if (!searchQuery.trim()) return items;
+    const q = searchQuery.toLowerCase();
+    return items.filter(
+      i => i.title.toLowerCase().includes(q) || `#${i.id}`.includes(q),
+    );
+  }, [items, searchQuery]);
+
+  // Collect unique states and types for filter dropdowns
+  const availableStates = useMemo(() => {
+    const states = new Set(items.map(i => i.state));
+    return Array.from(states).sort();
+  }, [items]);
+
+  const availableTypes = useMemo(() => {
+    const types = new Set(items.map(i => i.workItemType));
+    return Array.from(types).sort();
+  }, [items]);
+
+  if (!config.organization || !config.project) {
+    return <ConfigWarning />;
+  }
+
+  if (error) {
+    return (
+      <div style={{ ...sidebarContainer, justifyContent: "center", alignItems: "center" }}>
+        <div style={{ padding: "16px", textAlign: "center" }}>
+          <div style={{ fontSize: "12px", color: "var(--text-error, #f87171)", marginBottom: "8px" }}>
+            Could not load work items
+          </div>
+          <div style={{ fontSize: "11px", color: "var(--text-secondary, #888)", marginBottom: "12px" }}>
+            {error}
+          </div>
+          <button onClick={() => fetchItems()} style={btnSecondarySmall}>
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={sidebarContainer}>
+      {/* Header */}
+      <div style={sidebarHeader}>
+        <span style={{ fontSize: "12px", fontWeight: 500, color: "var(--text-primary, #e0e0e0)" }}>
+          Work Items
+        </span>
+        <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+          <button
+            onClick={() => fetchItems()}
+            disabled={loading}
+            title="Refresh work items"
+            style={sidebarHeaderBtn}
+          >
+            {"\u21bb"}
+          </button>
+          <button
+            onClick={() => workItemState.setCreatingNew(true)}
+            title="Create a new work item"
+            style={sidebarHeaderBtn}
+          >
+            + New
+          </button>
+        </div>
+      </div>
+
+      {/* Search + filters */}
+      <div style={{ padding: "6px 8px", borderBottom: "1px solid var(--border-color, #222)", display: "flex", gap: "4px", alignItems: "center", flexWrap: "wrap" }}>
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            workItemState.setSearchQuery((e.target as HTMLInputElement).value)
+          }
+          placeholder="Filter\u2026"
+          style={{
+            flex: 1,
+            minWidth: "60px",
+            padding: "4px 6px",
+            fontSize: "11px",
+            border: "1px solid var(--border-color, #333)",
+            borderRadius: "4px",
+            background: "var(--input-bg, #1a1a2e)",
+            color: "var(--text-primary, #e0e0e0)",
+            fontFamily: "var(--font-family)",
+            outline: "none",
+          }}
+        />
+        <select
+          value={stateFilter}
+          onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+            workItemState.setStateFilter((e.target as HTMLSelectElement).value)
+          }
+          style={filterSelect}
+        >
+          <option value="">All States</option>
+          {availableStates.map(s => <option key={s} value={s}>{s}</option>)}
+        </select>
+        <select
+          value={typeFilter}
+          onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+            workItemState.setTypeFilter((e.target as HTMLSelectElement).value)
+          }
+          style={filterSelect}
+        >
+          <option value="">All Types</option>
+          {availableTypes.map(t => <option key={t} value={t}>{t}</option>)}
+        </select>
+      </div>
+
+      {/* Work item list */}
+      <div style={{ flex: 1, overflowY: "auto" }}>
+        {loading && items.length === 0 ? (
+          <div style={{ padding: "16px", textAlign: "center", fontSize: "12px", color: "var(--text-secondary, #888)" }}>
+            Loading work items{"\u2026"}
+          </div>
+        ) : filteredItems.length === 0 ? (
+          <div style={{ padding: "16px", textAlign: "center", fontSize: "12px", color: "var(--text-secondary, #888)" }}>
+            {searchQuery ? "No matching work items" : "No work items found"}
+          </div>
+        ) : (
+          <div style={{ padding: "2px 0" }}>
+            {filteredItems.map(item => (
+              <div
+                key={item.id}
+                onClick={() => workItemState.setSelectedItem(item.id)}
+                style={{
+                  padding: "8px 10px",
+                  cursor: "pointer",
+                  background: item.id === selected ? "var(--item-active-bg, #2a2a4a)" : "transparent",
+                }}
+              >
+                {/* Top row: type indicator + ID + title */}
+                <div style={{ display: "flex", alignItems: "center", gap: "6px", minWidth: 0 }}>
+                  <span
+                    style={{
+                      width: "3px",
+                      height: "14px",
+                      borderRadius: "2px",
+                      background: typeColor(item.workItemType),
+                      flexShrink: 0,
+                    }}
+                  />
+                  <span style={{ fontSize: "10px", color: "var(--text-secondary, #888)", flexShrink: 0 }}>
+                    #{item.id}
+                  </span>
+                  <span style={{ fontSize: "12px", color: "var(--text-primary, #e0e0e0)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                    {item.title}
+                  </span>
+                </div>
+                {/* Bottom row: type + state + time */}
+                <div style={{ display: "flex", alignItems: "center", gap: "4px", marginTop: "4px", paddingLeft: "9px" }}>
+                  <span style={{ fontSize: "9px", color: typeColor(item.workItemType), flexShrink: 0 }}>
+                    {item.workItemType}
+                  </span>
+                  {(() => {
+                    const colors = stateColor(item.state);
+                    return (
+                      <span
+                        style={{
+                          fontSize: "9px",
+                          padding: "0 5px",
+                          borderRadius: "10px",
+                          backgroundColor: colors.bg,
+                          color: colors.fg,
+                          border: `1px solid ${colors.border}`,
+                          flexShrink: 0,
+                        }}
+                      >
+                        {item.state}
+                      </span>
+                    );
+                  })()}
+                  {item.assignedTo && (
+                    <span style={{ fontSize: "9px", color: "var(--text-secondary, #666)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                      {item.assignedTo}
+                    </span>
+                  )}
+                  <span style={{ fontSize: "10px", color: "var(--text-secondary, #888)", marginLeft: "auto", flexShrink: 0 }}>
+                    {relativeTime(item.changedDate)}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// MainPanel
+// ---------------------------------------------------------------------------
+
+export function MainPanel({ api }: PanelProps) {
+  const [selected, setSelected] = useState<number | null>(workItemState.selectedId);
+  const [creatingNew, setCreatingNew] = useState(workItemState.creatingNew);
+  const [detail, setDetail] = useState<WorkItemDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [showAgentDialog, setShowAgentDialog] = useState(false);
+  const [showStateDialog, setShowStateDialog] = useState(false);
+  const [detailVersion, setDetailVersion] = useState(0);
+
+  const config = getConfig(api);
+
+  // Create form state
+  const [newType, setNewType] = useState(config.defaultWorkItemType || "Task");
+  const [newTitle, setNewTitle] = useState("");
+  const [newDescription, setNewDescription] = useState("");
+  const [newAreaPath, setNewAreaPath] = useState(config.areaPath || "");
+  const [newIterationPath, setNewIterationPath] = useState(config.iterationPath || "");
+  const [newPriority, setNewPriority] = useState("3");
+  const [newTags, setNewTags] = useState("");
+  const [creating, setCreating] = useState(false);
+
+  // Edit mode state
+  const [editing, setEditing] = useState(false);
+  const [editTitle, setEditTitle] = useState("");
+  const [editDescription, setEditDescription] = useState("");
+  const [editAssignedTo, setEditAssignedTo] = useState("");
+  const [editTags, setEditTags] = useState("");
+
+  // Comment form state
+  const [commentBody, setCommentBody] = useState("");
+
+  // Refs for command-triggered actions
+  const handleToggleStateRef = useRef<(() => void) | null>(null);
+  const handleViewInBrowserRef = useRef<(() => void) | null>(null);
+
+  // Subscribe to shared state
+  useEffect(() => {
+    const unsub = workItemState.subscribe(() => {
+      setSelected(workItemState.selectedId);
+      setCreatingNew(workItemState.creatingNew);
+
+      const action = workItemState.consumeAction();
+      if (action === "assignAgent") setShowAgentDialog(true);
+      if (action === "toggleState") handleToggleStateRef.current?.();
+      if (action === "viewInBrowser") handleViewInBrowserRef.current?.();
+    });
+    return unsub;
+  }, []);
+
+  // Fetch detail when selection changes
+  useEffect(() => {
+    if (selected === null) {
+      setDetail(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setEditing(false);
+
+    const fetchDetail = async () => {
+      const args = [
+        "boards", "work-item", "show",
+        "--id", String(selected),
+        "--output", "json",
+        ...baseArgs(config),
+      ];
+      const r = await api.process.exec("az", args, { timeout: 30000 });
+      if (cancelled) return;
+      if (r.exitCode === 0 && r.stdout.trim()) {
+        const raw = JSON.parse(r.stdout) as Record<string, unknown>;
+        const parsed = parseWorkItemDetail(raw, config);
+
+        // Fetch comments
+        const comments = await fetchComments(api, config, parsed.id);
+        if (cancelled) return;
+        parsed.comments = comments;
+
+        setDetail(parsed);
+      } else {
+        setDetail(null);
+      }
+      setLoading(false);
+    };
+
+    fetchDetail().catch(() => {
+      if (!cancelled) { setDetail(null); setLoading(false); }
+    });
+
+    return () => { cancelled = true; };
+  }, [selected, api, detailVersion, config.organization, config.project]);
+
+  const refreshDetail = useCallback(() => setDetailVersion(v => v + 1), []);
+
+  // -- Edit handlers -------------------------------------------------------
+
+  const startEditing = useCallback(() => {
+    if (!detail) return;
+    setEditTitle(detail.title);
+    setEditDescription(detail.description ? stripHtml(detail.description) : "");
+    setEditAssignedTo(detail.assignedTo);
+    setEditTags(detail.tags);
+    setEditing(true);
+  }, [detail]);
+
+  const saveEdit = useCallback(async () => {
+    if (!detail) return;
+    const args: string[] = [
+      "boards", "work-item", "update",
+      "--id", String(detail.id),
+      "--output", "json",
+      ...baseArgs(config),
+    ];
+
+    const fields: string[] = [];
+    if (editTitle.trim() !== detail.title) {
+      args.push("--title", editTitle.trim());
+    }
+    if (editDescription !== stripHtml(detail.description || "")) {
+      args.push("--description", editDescription);
+    }
+    if (editAssignedTo !== detail.assignedTo) {
+      if (editAssignedTo.trim()) {
+        fields.push(`System.AssignedTo=${editAssignedTo.trim()}`);
+      } else {
+        fields.push("System.AssignedTo=");
+      }
+    }
+    if (editTags !== detail.tags) {
+      fields.push(`System.Tags=${editTags}`);
+    }
+
+    if (fields.length > 0) {
+      args.push("--fields", ...fields);
+    }
+
+    // Check if anything actually changed
+    const baseArgCount = 5 + baseArgs(config).length; // boards, work-item, update, --id, N, --output, json + base
+    if (args.length <= baseArgCount + 2) { // +2 for --output json
+      setEditing(false);
+      return;
+    }
+
+    const r = await api.process.exec("az", args, { timeout: 30000 });
+    if (r.exitCode === 0) {
+      api.ui.showNotice("Work item updated");
+      setEditing(false);
+      refreshDetail();
+      workItemState.requestRefresh();
+    } else {
+      api.ui.showError(r.stderr.trim() || "Failed to update work item");
+    }
+  }, [detail, editTitle, editDescription, editAssignedTo, editTags, api, config, refreshDetail]);
+
+  // -- Comment handler -----------------------------------------------------
+
+  const handleAddComment = useCallback(async () => {
+    if (!detail || !commentBody.trim()) return;
+    const args = [
+      "boards", "work-item", "update",
+      "--id", String(detail.id),
+      "--discussion", commentBody.trim(),
+      "--output", "json",
+      ...baseArgs(config),
+    ];
+    const r = await api.process.exec("az", args, { timeout: 30000 });
+    if (r.exitCode === 0) {
+      api.ui.showNotice("Comment added");
+      setCommentBody("");
+      refreshDetail();
+    } else {
+      api.ui.showError(r.stderr.trim() || "Failed to add comment");
+    }
+  }, [detail, commentBody, api, config, refreshDetail]);
+
+  // -- State change handler ------------------------------------------------
+
+  const handleToggleState = useCallback(() => {
+    if (!detail) return;
+    setShowStateDialog(true);
+  }, [detail]);
+
+  // Keep refs current
+  handleToggleStateRef.current = handleToggleState;
+  handleViewInBrowserRef.current = detail ? () => api.ui.openExternalUrl(detail.url) : null;
+
+  // -- Create form handlers ------------------------------------------------
+
+  const handleCreate = useCallback(async () => {
+    if (!newTitle.trim()) return;
+    setCreating(true);
+    const args = [
+      "boards", "work-item", "create",
+      "--type", newType,
+      "--title", newTitle.trim(),
+      "--output", "json",
+      ...baseArgs(config),
+    ];
+
+    if (newDescription.trim()) {
+      args.push("--description", newDescription.trim());
+    }
+    if (newAreaPath.trim()) {
+      args.push("--area", newAreaPath.trim());
+    }
+    if (newIterationPath.trim()) {
+      args.push("--iteration", newIterationPath.trim());
+    }
+
+    const fields: string[] = [];
+    if (newPriority) {
+      fields.push(`Microsoft.VSTS.Common.Priority=${newPriority}`);
+    }
+    if (newTags.trim()) {
+      fields.push(`System.Tags=${newTags.trim()}`);
+    }
+    if (fields.length > 0) {
+      args.push("--fields", ...fields);
+    }
+
+    const r = await api.process.exec("az", args, { timeout: 30000 });
+    setCreating(false);
+    if (r.exitCode === 0) {
+      let createdId = "";
+      try {
+        const parsed = JSON.parse(r.stdout);
+        createdId = ` #${parsed.id}`;
+      } catch { /* ignore */ }
+      api.ui.showNotice(`Work item${createdId} created`);
+      setNewTitle("");
+      setNewDescription("");
+      setNewTags("");
+      setNewPriority("3");
+      workItemState.setCreatingNew(false);
+      workItemState.requestRefresh();
+    } else {
+      api.ui.showError(r.stderr.trim() || "Failed to create work item");
+    }
+  }, [newType, newTitle, newDescription, newAreaPath, newIterationPath, newPriority, newTags, api, config]);
+
+  const handleCancelCreate = useCallback(() => {
+    setNewTitle("");
+    setNewDescription("");
+    setNewTags("");
+    setNewPriority("3");
+    workItemState.setCreatingNew(false);
+  }, []);
+
+  // ── Create form view ────────────────────────────────────────────────
+
+  if (creatingNew) {
+    return (
+      <div style={mainContainer}>
+        <div style={mainHeader}>
+          <span style={{ fontSize: "13px", fontWeight: 500, color: "var(--text-primary, #e0e0e0)" }}>
+            New Work Item
+          </span>
+        </div>
+        <div style={{ flex: 1, overflowY: "auto", padding: "16px" }}>
+          <div style={{ display: "flex", flexDirection: "column", gap: "14px" }}>
+            {/* Type */}
+            <div>
+              <label style={formLabel}>Type</label>
+              <select
+                value={newType}
+                onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                  setNewType((e.target as HTMLSelectElement).value)
+                }
+                style={formInput}
+              >
+                <option value="Epic">Epic</option>
+                <option value="Feature">Feature</option>
+                <option value="User Story">User Story</option>
+                <option value="Product Backlog Item">Product Backlog Item</option>
+                <option value="Bug">Bug</option>
+                <option value="Task">Task</option>
+                <option value="Issue">Issue</option>
+                <option value="Impediment">Impediment</option>
+              </select>
+            </div>
+
+            {/* Title */}
+            <div>
+              <label style={formLabel}>Title</label>
+              <input
+                type="text"
+                value={newTitle}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setNewTitle((e.target as HTMLInputElement).value)
+                }
+                placeholder="Work item title"
+                style={formInput}
+                autoFocus
+              />
+            </div>
+
+            {/* Description */}
+            <div>
+              <label style={formLabel}>Description</label>
+              <textarea
+                value={newDescription}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                  setNewDescription((e.target as HTMLTextAreaElement).value)
+                }
+                placeholder="Describe the work item\u2026"
+                rows={8}
+                style={{ ...formInput, resize: "vertical" as const }}
+              />
+            </div>
+
+            {/* Area Path */}
+            <div>
+              <label style={formLabel}>Area Path</label>
+              <input
+                type="text"
+                value={newAreaPath}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setNewAreaPath((e.target as HTMLInputElement).value)
+                }
+                placeholder={config.areaPath || config.project}
+                style={formInput}
+              />
+            </div>
+
+            {/* Iteration Path */}
+            <div>
+              <label style={formLabel}>Iteration Path</label>
+              <input
+                type="text"
+                value={newIterationPath}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setNewIterationPath((e.target as HTMLInputElement).value)
+                }
+                placeholder={config.iterationPath || config.project}
+                style={formInput}
+              />
+            </div>
+
+            {/* Priority */}
+            <div>
+              <label style={formLabel}>Priority</label>
+              <select
+                value={newPriority}
+                onChange={(e: React.ChangeEvent<HTMLSelectElement>) =>
+                  setNewPriority((e.target as HTMLSelectElement).value)
+                }
+                style={formInput}
+              >
+                <option value="1">1 - Critical</option>
+                <option value="2">2 - High</option>
+                <option value="3">3 - Medium</option>
+                <option value="4">4 - Low</option>
+              </select>
+            </div>
+
+            {/* Tags */}
+            <div>
+              <label style={formLabel}>Tags</label>
+              <input
+                type="text"
+                value={newTags}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setNewTags((e.target as HTMLInputElement).value)
+                }
+                placeholder="Tag1; Tag2; Tag3"
+                style={formInput}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Bottom bar */}
+        <div style={mainFooter}>
+          <button onClick={handleCancelCreate} disabled={creating} style={btnSecondarySmall}>
+            Cancel
+          </button>
+          <button
+            onClick={handleCreate}
+            disabled={creating || !newTitle.trim()}
+            style={{
+              ...btnPrimarySmall,
+              opacity: creating || !newTitle.trim() ? 0.5 : 1,
+            }}
+          >
+            {creating ? "Creating\u2026" : "Create Work Item"}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Empty state ─────────────────────────────────────────────────────
+
+  if (selected === null) {
+    return (
+      <div style={{ ...mainContainer, justifyContent: "center", alignItems: "center" }}>
+        <span style={{ fontSize: "12px", color: "var(--text-secondary, #888)" }}>
+          Select a work item to view details
+        </span>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div style={{ ...mainContainer, justifyContent: "center", alignItems: "center" }}>
+        <span style={{ fontSize: "12px", color: "var(--text-secondary, #888)" }}>
+          Loading work item{"\u2026"}
+        </span>
+      </div>
+    );
+  }
+
+  if (!detail) {
+    return (
+      <div style={{ ...mainContainer, justifyContent: "center", alignItems: "center" }}>
+        <span style={{ fontSize: "12px", color: "var(--text-secondary, #888)" }}>
+          Failed to load work item details
+        </span>
+      </div>
+    );
+  }
+
+  // ── Detail view ─────────────────────────────────────────────────────
+
+  const sc = stateColor(detail.state);
+  const stateBadge: React.CSSProperties = {
+    fontSize: "10px",
+    padding: "2px 8px",
+    borderRadius: "10px",
+    cursor: "pointer",
+    border: `1px solid ${sc.border}`,
+    background: sc.bg,
+    color: sc.fg,
+  };
+
+  return (
+    <div style={{ ...mainContainer, position: "relative" }}>
+      {/* Header bar */}
+      <div style={{ ...mainHeader, gap: "8px" }}>
+        {editing ? (
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <input
+              type="text"
+              value={editTitle}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setEditTitle((e.target as HTMLInputElement).value)
+              }
+              style={{ ...formInput, fontSize: "13px" }}
+            />
+          </div>
+        ) : (
+          <div style={{ flex: 1, minWidth: 0, display: "flex", alignItems: "center", gap: "6px" }}>
+            <span
+              style={{
+                width: "3px",
+                height: "16px",
+                borderRadius: "2px",
+                background: typeColor(detail.workItemType),
+                flexShrink: 0,
+              }}
+            />
+            <span style={{ fontSize: "12px", color: "var(--text-secondary, #888)", flexShrink: 0 }}>
+              #{detail.id}
+            </span>
+            <span style={{ fontSize: "13px", fontWeight: 500, color: "var(--text-primary, #e0e0e0)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+              {detail.title}
+            </span>
+          </div>
+        )}
+
+        {editing ? (
+          <>
+            <button onClick={saveEdit} style={{ ...btnPrimarySmall, flexShrink: 0 }}>Save</button>
+            <button onClick={() => setEditing(false)} style={{ ...btnSecondarySmall, flexShrink: 0 }}>Cancel</button>
+          </>
+        ) : (
+          <>
+            <button onClick={startEditing} style={{ ...btnSecondarySmall, flexShrink: 0 }}>Edit</button>
+            <button onClick={() => api.ui.openExternalUrl(detail.url)} style={{ ...btnSecondarySmall, flexShrink: 0 }}>
+              View in Browser
+            </button>
+            <button onClick={() => setShowAgentDialog(true)} style={{ ...btnPrimarySmall, flexShrink: 0 }}>
+              Assign to Agent
+            </button>
+          </>
+        )}
+      </div>
+
+      {/* Metadata row */}
+      <div style={{ display: "flex", alignItems: "center", flexWrap: "wrap", gap: "6px", padding: "8px 16px", borderBottom: "1px solid var(--border-color, #222)", background: "var(--panel-bg-alt, rgba(0,0,0,0.15))" }}>
+        <button onClick={() => setShowStateDialog(true)} style={stateBadge} title="Change state">
+          {detail.state}
+        </button>
+        <span style={{ fontSize: "10px", color: typeColor(detail.workItemType), fontWeight: 500 }}>
+          {detail.workItemType}
+        </span>
+        {detail.priority > 0 && (
+          <span style={{ fontSize: "10px", color: "var(--text-secondary, #888)" }}>
+            P{detail.priority} ({priorityLabel(detail.priority)})
+          </span>
+        )}
+        <span style={{ fontSize: "10px", color: "var(--text-secondary, #888)" }}>
+          by {detail.createdBy}
+        </span>
+        <span style={{ fontSize: "10px", color: "var(--text-secondary, #888)" }}>
+          created {relativeTime(detail.createdDate)}
+        </span>
+
+        {/* Assigned To */}
+        {editing ? (
+          <input
+            type="text"
+            value={editAssignedTo}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setEditAssignedTo((e.target as HTMLInputElement).value)
+            }
+            placeholder="Assigned to"
+            style={{ fontSize: "10px", padding: "2px 6px", background: "var(--input-bg, #1a1a2e)", border: "1px solid var(--border-color, #333)", borderRadius: "4px", color: "var(--text-primary, #e0e0e0)", fontFamily: "var(--font-family)", outline: "none" }}
+          />
+        ) : detail.assignedTo ? (
+          <span style={{ fontSize: "10px", padding: "1px 6px", background: "var(--item-active-bg, #2a2a4a)", color: "var(--text-secondary, #aaa)", borderRadius: "4px" }}>
+            {detail.assignedTo}
+          </span>
+        ) : null}
+
+        {/* Area + Iteration paths */}
+        {detail.areaPath && (
+          <span style={{ fontSize: "9px", color: "var(--text-secondary, #666)" }}>
+            Area: {detail.areaPath}
+          </span>
+        )}
+        {detail.iterationPath && (
+          <span style={{ fontSize: "9px", color: "var(--text-secondary, #666)" }}>
+            Iter: {detail.iterationPath}
+          </span>
+        )}
+
+        {/* Tags */}
+        {editing ? (
+          <input
+            type="text"
+            value={editTags}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              setEditTags((e.target as HTMLInputElement).value)
+            }
+            placeholder="Tags (semicolon separated)"
+            style={{ fontSize: "10px", padding: "2px 6px", background: "var(--input-bg, #1a1a2e)", border: "1px solid var(--border-color, #333)", borderRadius: "4px", color: "var(--text-primary, #e0e0e0)", fontFamily: "var(--font-family)", outline: "none" }}
+          />
+        ) : detail.tags ? (
+          detail.tags.split(";").map(tag => tag.trim()).filter(Boolean).map(tag => (
+            <span
+              key={tag}
+              style={{
+                fontSize: "9px",
+                padding: "0 5px",
+                borderRadius: "10px",
+                backgroundColor: "rgba(100,100,200,0.15)",
+                color: "#8888cc",
+                border: "1px solid rgba(100,100,200,0.3)",
+              }}
+            >
+              {tag}
+            </span>
+          ))
+        ) : null}
+      </div>
+
+      {/* Scrollable content */}
+      <div style={{ flex: 1, overflowY: "auto" }}>
+        {/* Description */}
+        {editing ? (
+          <div style={{ padding: "12px 16px", borderBottom: "1px solid var(--border-color, #222)" }}>
+            <textarea
+              value={editDescription}
+              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                setEditDescription((e.target as HTMLTextAreaElement).value)
+              }
+              placeholder="Work item description\u2026"
+              rows={10}
+              style={{ ...formInput, resize: "vertical" as const }}
+            />
+          </div>
+        ) : detail.description ? (
+          <div style={{ padding: "12px 16px", borderBottom: "1px solid var(--border-color, #222)" }}>
+            <pre style={preStyle}>{stripHtml(detail.description)}</pre>
+          </div>
+        ) : (
+          <div style={{ padding: "12px 16px", fontSize: "12px", color: "var(--text-secondary, #888)", fontStyle: "italic", borderBottom: "1px solid var(--border-color, #222)" }}>
+            No description provided.
+          </div>
+        )}
+
+        {/* Discussion / Comments */}
+        {detail.comments.length > 0 && (
+          <div style={{ padding: "12px 16px", borderBottom: "1px solid var(--border-color, #222)" }}>
+            <div style={{ fontSize: "12px", fontWeight: 500, color: "var(--text-primary, #e0e0e0)", marginBottom: "12px" }}>
+              {detail.comments.length} comment{detail.comments.length === 1 ? "" : "s"}
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: "10px" }}>
+              {detail.comments.map((comment, i) => (
+                <div
+                  key={i}
+                  style={{
+                    border: "1px solid var(--border-color, #222)",
+                    borderRadius: "6px",
+                    overflow: "hidden",
+                  }}
+                >
+                  <div style={{ display: "flex", alignItems: "center", gap: "8px", padding: "6px 10px", background: "var(--panel-bg-alt, rgba(0,0,0,0.15))", borderBottom: "1px solid var(--border-color, #222)" }}>
+                    <span style={{ fontSize: "12px", fontWeight: 500, color: "var(--text-primary, #e0e0e0)" }}>
+                      {comment.author}
+                    </span>
+                    <span style={{ fontSize: "10px", color: "var(--text-secondary, #888)" }}>
+                      {relativeTime(comment.createdDate)}
+                    </span>
+                  </div>
+                  <div style={{ padding: "8px 10px" }}>
+                    <pre style={preStyle}>{stripHtml(comment.body)}</pre>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Add comment */}
+        <div style={{ padding: "12px 16px" }}>
+          <div style={{ fontSize: "12px", fontWeight: 500, color: "var(--text-primary, #e0e0e0)", marginBottom: "8px" }}>
+            Add a comment
+          </div>
+          <textarea
+            value={commentBody}
+            onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+              setCommentBody((e.target as HTMLTextAreaElement).value)
+            }
+            placeholder="Write a comment\u2026"
+            rows={3}
+            style={{ ...formInput, resize: "vertical" as const }}
+          />
+          <div style={{ display: "flex", justifyContent: "flex-end", marginTop: "8px" }}>
+            <button
+              onClick={handleAddComment}
+              disabled={!commentBody.trim()}
+              style={{
+                ...btnPrimarySmall,
+                opacity: commentBody.trim() ? 1 : 0.5,
+              }}
+            >
+              Comment
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Agent dialog overlay */}
+      {showAgentDialog && detail && (
+        <SendToAgentDialog
+          api={api}
+          item={detail}
+          onClose={() => setShowAgentDialog(false)}
+        />
+      )}
+
+      {/* State picker dialog */}
+      {showStateDialog && detail && (
+        <StatePickerDialog
+          api={api}
+          item={detail}
+          config={config}
+          onClose={() => setShowStateDialog(false)}
+          onStateChanged={() => {
+            refreshDetail();
+            workItemState.requestRefresh();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shared styles
+// ---------------------------------------------------------------------------
+
+const sidebarContainer: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  height: "100%",
+  fontFamily: "var(--font-family)",
+  background: "var(--sidebar-bg, #181825)",
+};
+
+const sidebarHeader: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  padding: "8px 10px",
+  borderBottom: "1px solid var(--border-color, #222)",
+};
+
+const sidebarHeaderBtn: React.CSSProperties = {
+  padding: "2px 8px",
+  fontSize: "12px",
+  color: "var(--text-secondary, #888)",
+  background: "transparent",
+  border: "none",
+  borderRadius: "4px",
+  cursor: "pointer",
+  fontFamily: "var(--font-family)",
+};
+
+const mainContainer: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  height: "100%",
+  fontFamily: "var(--font-family)",
+  background: "var(--panel-bg, #1e1e2e)",
+};
+
+const mainHeader: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  padding: "8px 16px",
+  borderBottom: "1px solid var(--border-color, #222)",
+  background: "var(--sidebar-bg, #181825)",
+  flexShrink: 0,
+};
+
+const mainFooter: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "flex-end",
+  gap: "8px",
+  padding: "10px 16px",
+  borderTop: "1px solid var(--border-color, #222)",
+  background: "var(--sidebar-bg, #181825)",
+  flexShrink: 0,
+};
+
+const formLabel: React.CSSProperties = {
+  display: "block",
+  fontSize: "12px",
+  fontWeight: 500,
+  color: "var(--text-secondary, #aaa)",
+  marginBottom: "4px",
+};
+
+const formInput: React.CSSProperties = {
+  width: "100%",
+  padding: "6px 10px",
+  borderRadius: "6px",
+  border: "1px solid var(--border-color, #333)",
+  background: "var(--input-bg, #1a1a2e)",
+  color: "var(--text-primary, #e0e0e0)",
+  fontSize: "13px",
+  fontFamily: "var(--font-family)",
+  boxSizing: "border-box",
+  outline: "none",
+};
+
+const filterSelect: React.CSSProperties = {
+  padding: "4px 4px",
+  fontSize: "10px",
+  border: "1px solid var(--border-color, #333)",
+  borderRadius: "4px",
+  background: "var(--input-bg, #1a1a2e)",
+  color: "var(--text-primary, #e0e0e0)",
+  fontFamily: "var(--font-family)",
+  cursor: "pointer",
+};
+
+const preStyle: React.CSSProperties = {
+  whiteSpace: "pre-wrap",
+  wordWrap: "break-word",
+  fontFamily: "var(--font-mono, monospace)",
+  fontSize: "13px",
+  lineHeight: 1.6,
+  color: "var(--text-primary, #e0e0e0)",
+  margin: 0,
+};
+
+const btnPrimarySmall: React.CSSProperties = {
+  padding: "4px 12px",
+  fontSize: "12px",
+  fontWeight: 500,
+  borderRadius: "4px",
+  border: "none",
+  background: "var(--accent-color, #4a6cf7)",
+  color: "#fff",
+  cursor: "pointer",
+  fontFamily: "var(--font-family)",
+};
+
+const btnSecondarySmall: React.CSSProperties = {
+  padding: "4px 12px",
+  fontSize: "12px",
+  borderRadius: "4px",
+  border: "1px solid var(--border-color, #333)",
+  background: "transparent",
+  color: "var(--text-primary, #e0e0e0)",
+  cursor: "pointer",
+  fontFamily: "var(--font-family)",
+};

--- a/plugins/ado-work-items/tsconfig.json
+++ b/plugins/ado-work-items/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "declaration": false,
+    "noEmit": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- Adds a new Clubhouse plugin (`ado-work-items`) for browsing, creating, editing, and managing Azure DevOps work items
- Modeled after the `github-issues` plugin with adaptations for the ADO ecosystem (WIQL queries, work item types, area/iteration paths, etc.)
- Uses the Azure CLI (`az boards`) for all ADO operations — no direct REST API calls needed

## Features

- **Browse work items** with state and type filter dropdowns, plus text search by title or ID
- **WIQL query support** — automatically builds queries based on configured project, area path, iteration path, and filters
- **Saved query integration** — optionally use a saved ADO query path instead of the default listing
- **Create work items** with type selector (Epic, Feature, User Story, PBI, Bug, Task, Issue, Impediment), priority, area/iteration paths, and tags
- **View and edit details inline** — title, description, assigned to, tags
- **Add discussion comments** via `az boards work-item update --discussion`
- **State change dialog** — presents available state transitions based on work item type
- **Agent assignment** — assign work items to durable agents with optional instruction persistence (same UX as github-issues)
- **7 declarative settings** — organization URL, project, team, default work item type, area path, iteration path, saved query path

## Configuration

Users configure via the plugin settings panel:
| Setting | Required | Description |
|---------|----------|-------------|
| Organization URL | Yes | `https://dev.azure.com/myorg` |
| Project | Yes | ADO project name |
| Team | No | Team name for scoping |
| Default Work Item Type | No | Default type for new items (defaults to Task) |
| Area Path | No | Filter by area path |
| Iteration Path | No | Filter by iteration path |
| Saved Query Path | No | Use a saved ADO query instead of WIQL |

## Architecture

- Single-file implementation (`src/main.tsx`, ~1100 lines) following the same patterns as `github-issues`
- Shared state object with pub-sub for cross-panel communication (SidebarPanel + MainPanel)
- `az` CLI whitelisted in `allowedCommands`; uses `az boards query`, `az boards work-item show/create/update`, and `az rest` for comments
- Two-step fetch pattern: WIQL query returns IDs, then batch `work-item show` fetches field data
- HTML stripping for ADO rich-text fields (descriptions, comments)

## Test plan

- [ ] Verify plugin loads in Clubhouse with no errors when `az` CLI is not installed (should show config warning)
- [ ] Configure organization URL and project in settings, verify work items load in sidebar
- [ ] Test state filter dropdown (All States, New, Active, Closed, etc.)
- [ ] Test type filter dropdown (Bug, Task, User Story, etc.)
- [ ] Test search filter by title and by ID (`#123`)
- [ ] Click a work item — verify detail view shows title, state, type, priority, assigned to, area/iteration paths, tags, description, and comments
- [ ] Test "Edit" mode — modify title, description, assigned to, tags, and save
- [ ] Test "Change State" dialog — verify state transitions work
- [ ] Test "Create Work Item" — fill in type, title, description, area/iteration paths, priority, tags
- [ ] Test "Add comment" — post a discussion comment
- [ ] Test "View in Browser" — opens ADO web portal
- [ ] Test "Assign to Agent" — verify agent dialog lists durable agents, instruction persistence works
- [ ] Test saved query path setting — verify it overrides the default WIQL listing
- [ ] Verify settings changes trigger automatic refresh of work item list
- [ ] TypeScript typecheck passes (`npm run typecheck`)
- [ ] Build succeeds (`npm run build`)

## Manual validation

- TypeScript typecheck: PASS
- esbuild bundle: PASS (62.2kb)
- No lint errors

---
Generated with [Claude Code](https://claude.com/claude-code)