### PR TITLE
fix: prep releases for new plugins and github-issues v0.1.1

### DIFF
--- a/plugins/ado-work-items/manifest.json
+++ b/plugins/ado-work-items/manifest.json
@@ -82,7 +82,6 @@
     "agents",
     "commands",
     "process",
-    "settings",
     "widgets"
   ],
   "allowedCommands": ["az"]

--- a/plugins/github-issues/manifest.json
+++ b/plugins/github-issues/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "github-issues",
   "name": "GitHub Issue Tracker",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Create and manage GitHub issues with template support, label validation, and agent assignment",
   "author": "Clubhouse Workshop",
   "engine": { "api": 0.5 },

--- a/plugins/github-issues/package.json
+++ b/plugins/github-issues/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-issues",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "license": "MIT",
   "description": "GitHub Issue Tracker plugin for Clubhouse with template support, label validation, and agent assignment",


### PR DESCRIPTION
## Summary
- Remove invalid `settings` permission from `ado-work-items` manifest (same bug fixed for github-issues in #33 — `settings` is not a valid `PluginPermission`)
- Bump `github-issues` to v0.1.1 so a re-release will update the registry entry (currently still lists the invalid `settings` permission from v0.1.0)

## After merge — tag releases
Once merged, create these tags on main to trigger the release pipeline for all unreleased plugins:

```bash
git tag -m "Release ado-work-items v0.1.0" ado-work-items-v0.1.0
git tag -m "Release wiki v1.0.0" wiki-v1.0.0
git tag -m "Release automations v0.1.0" automations-v0.1.0
git tag -m "Release github-issues v0.1.1" github-issues-v0.1.1
git push origin ado-work-items-v0.1.0 wiki-v1.0.0 automations-v0.1.0 github-issues-v0.1.1
```

## Test plan
- [x] `ado-work-items` builds successfully
- [x] `wiki` builds successfully
- [x] `automations` builds successfully
- [x] `github-issues` builds successfully, 47/47 tests pass
- [x] Verified `settings` is not in the v0.5 `PluginPermission` type

🤖 Generated with [Claude Code](https://claude.com/claude-code)