### PR TITLE
ci: use PR-based registry updates in release pipeline

### DIFF
--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: release-registry
@@ -191,13 +192,19 @@ jobs:
             fs.writeFileSync('registry/registry.json', JSON.stringify(registry, null, 2) + '\n');
           "
 
-      - name: Push registry update to main
+      - name: Open registry update PR
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          BRANCH="registry-update/${{ steps.tag.outputs.tag }}"
+          git checkout -b "$BRANCH"
           git add registry/registry.json
           git diff --cached --quiet && echo "No registry changes" && exit 0
           git commit -m "registry: update ${{ steps.tag.outputs.plugin_id }} to v${{ steps.tag.outputs.version }}"
-          # Pull latest main and rebase to handle concurrent releases
-          git pull --rebase origin main
-          git push origin HEAD:main
+          git push --force origin "$BRANCH"
+          gh pr create \
+            --title "registry: update ${{ steps.tag.outputs.plugin_id }} to v${{ steps.tag.outputs.version }}" \
+            --body "Automated registry update from release pipeline." \
+            --base main
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/registry/README.md
+++ b/registry/README.md
@@ -35,14 +35,12 @@ git push origin my-plugin-v1.0.0
 CI handles the rest automatically:
 1. Builds the plugin and validates the manifest
 2. Creates a zip artifact and GitHub Release
-3. Updates `registry.json` directly on main with the new version's sha256, size, and permissions
+3. Opens a PR to update `registry.json` with the new version's sha256, size, and permissions
 
 You can also trigger a release manually:
 ```bash
 gh workflow run "Release Plugin" -f tag=my-plugin-v1.0.0
 ```
-
-> **Note:** The GitHub Actions bot must be allowed to bypass branch protection on `main` so it can push registry updates directly.
 
 ## Registry format
 


### PR DESCRIPTION
## Summary
- Switch release workflow from pushing registry updates directly to main to opening a PR instead
- Adds `pull-requests: write` permission to the workflow
- Fixes the branch protection violation that was blocking all registry updates

The `github-actions[bot]` can't bypass branch protection rules, so the direct push approach was failing on every release. This switches to a PR-based flow that works with branch protection as-is.

## Test plan
- [ ] Merge this PR, then re-trigger the 4 pending releases
- [ ] Verify each creates a registry update PR that can be merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)