### PR TITLE
feat(themes): add accent2 and overlay slots to all 30 Workshop plugin themes

### DIFF
--- a/plugins/fall-themes/manifest.json
+++ b/plugins/fall-themes/manifest.json
@@ -30,7 +30,9 @@
           "warning": "#c89028",
           "error": "#c84830",
           "info": "#5080a8",
-          "success": "#508848"
+          "success": "#508848",
+          "accent2": "#5080a8",
+          "overlay": "#b08d7a"
         },
         "hljs": {
           "keyword": "#a05020",
@@ -97,7 +99,9 @@
           "warning": "#987030",
           "error": "#b84838",
           "info": "#5080a0",
-          "success": "#588838"
+          "success": "#588838",
+          "accent2": "#5080a0",
+          "overlay": "#a39379"
         },
         "hljs": {
           "keyword": "#885898",
@@ -164,7 +168,9 @@
           "warning": "#c88828",
           "error": "#c04438",
           "info": "#4888a8",
-          "success": "#508840"
+          "success": "#508840",
+          "accent2": "#4888a8",
+          "overlay": "#af8c73"
         },
         "hljs": {
           "keyword": "#d07028",
@@ -228,7 +234,9 @@
           "warning": "#a88020",
           "error": "#b84838",
           "info": "#4880a8",
-          "success": "#488838"
+          "success": "#488838",
+          "accent2": "#4880a8",
+          "overlay": "#9b9173"
         },
         "hljs": {
           "keyword": "#507838",
@@ -292,7 +300,9 @@
           "warning": "#d8a840",
           "error": "#e06060",
           "info": "#6898c0",
-          "success": "#68a868"
+          "success": "#68a868",
+          "accent2": "#e8a060",
+          "overlay": "#6e5858"
         },
         "hljs": {
           "keyword": "#e87048",

--- a/plugins/neon-themes/manifest.json
+++ b/plugins/neon-themes/manifest.json
@@ -30,7 +30,9 @@
           "warning": "#ffcc00",
           "error": "#ff3050",
           "info": "#00d8ff",
-          "success": "#00e870"
+          "success": "#00e870",
+          "accent2": "#00d8ff",
+          "overlay": "#505074"
         },
         "hljs": {
           "keyword": "#ff2090",
@@ -101,7 +103,9 @@
           "warning": "#fede5d",
           "error": "#fe4450",
           "info": "#36f9f6",
-          "success": "#72f1b8"
+          "success": "#72f1b8",
+          "accent2": "#72f1b8",
+          "overlay": "#624c80"
         },
         "hljs": {
           "keyword": "#ff7edb",
@@ -169,7 +173,9 @@
           "warning": "#e0c040",
           "error": "#e83838",
           "info": "#38a8e0",
-          "success": "#38d8a0"
+          "success": "#38d8a0",
+          "accent2": "#38d8a0",
+          "overlay": "#504868"
         },
         "hljs": {
           "keyword": "#e83838",
@@ -236,7 +242,9 @@
           "warning": "#ffe020",
           "error": "#ff4060",
           "info": "#00b0ff",
-          "success": "#00e068"
+          "success": "#00e068",
+          "accent2": "#00e068",
+          "overlay": "#415a74"
         },
         "hljs": {
           "keyword": "#00b0ff",
@@ -304,7 +312,9 @@
           "warning": "#d0a028",
           "error": "#d04858",
           "info": "#5080d0",
-          "success": "#40a070"
+          "success": "#40a070",
+          "accent2": "#5080d0",
+          "overlay": "#9e8cba"
         },
         "hljs": {
           "keyword": "#e060a0",

--- a/plugins/ocean-themes/manifest.json
+++ b/plugins/ocean-themes/manifest.json
@@ -30,7 +30,9 @@
           "warning": "#c89828",
           "error": "#d04848",
           "info": "#2898b0",
-          "success": "#38a070"
+          "success": "#38a070",
+          "accent2": "#2898b0",
+          "overlay": "#aa9592"
         },
         "hljs": {
           "keyword": "#2898b0",
@@ -94,7 +96,9 @@
           "warning": "#a89030",
           "error": "#c05048",
           "info": "#4080a8",
-          "success": "#3a8878"
+          "success": "#3a8878",
+          "accent2": "#4080a8",
+          "overlay": "#7e9a8f"
         },
         "hljs": {
           "keyword": "#6858a0",
@@ -158,7 +162,9 @@
           "warning": "#a89030",
           "error": "#c05050",
           "info": "#3878b0",
-          "success": "#489070"
+          "success": "#489070",
+          "accent2": "#489070",
+          "overlay": "#8c9aa8"
         },
         "hljs": {
           "keyword": "#3878b0",
@@ -225,7 +231,9 @@
           "warning": "#d0b050",
           "error": "#e07070",
           "info": "#4090c0",
-          "success": "#40c890"
+          "success": "#40c890",
+          "accent2": "#4090c0",
+          "overlay": "#456078"
         },
         "hljs": {
           "keyword": "#30b8d0",
@@ -293,7 +301,9 @@
           "warning": "#c8a848",
           "error": "#d06868",
           "info": "#4890b8",
-          "success": "#48b880"
+          "success": "#48b880",
+          "accent2": "#48b880",
+          "overlay": "#364858"
         },
         "hljs": {
           "keyword": "#4890b8",

--- a/plugins/spring-themes/manifest.json
+++ b/plugins/spring-themes/manifest.json
@@ -30,7 +30,9 @@
           "warning": "#b8892e",
           "error": "#c44d5e",
           "info": "#6b8fb8",
-          "success": "#5d9068"
+          "success": "#5d9068",
+          "accent2": "#6b8fb8",
+          "overlay": "#b68f9d"
         },
         "hljs": {
           "keyword": "#b85e8a",
@@ -100,7 +102,9 @@
           "warning": "#a88530",
           "error": "#c05040",
           "info": "#5080b0",
-          "success": "#4a8f52"
+          "success": "#4a8f52",
+          "accent2": "#5080b0",
+          "overlay": "#879e83"
         },
         "hljs": {
           "keyword": "#7b60a8",
@@ -164,7 +168,9 @@
           "warning": "#a88838",
           "error": "#c04e68",
           "info": "#5e85b8",
-          "success": "#5e9068"
+          "success": "#5e9068",
+          "accent2": "#5e85b8",
+          "overlay": "#988ab0"
         },
         "hljs": {
           "keyword": "#8a5cb5",
@@ -232,7 +238,9 @@
           "warning": "#b88c20",
           "error": "#c04838",
           "info": "#5080b0",
-          "success": "#588a48"
+          "success": "#588a48",
+          "accent2": "#5080b0",
+          "overlay": "#a99d7c"
         },
         "hljs": {
           "keyword": "#9858a0",
@@ -296,7 +304,9 @@
           "warning": "#d8c070",
           "error": "#e08898",
           "info": "#78b0d0",
-          "success": "#78c088"
+          "success": "#78c088",
+          "accent2": "#88c0d8",
+          "overlay": "#626b8a"
         },
         "hljs": {
           "keyword": "#c8a0e0",

--- a/plugins/summer-themes/manifest.json
+++ b/plugins/summer-themes/manifest.json
@@ -30,7 +30,9 @@
           "warning": "#c89030",
           "error": "#c84848",
           "info": "#5888b0",
-          "success": "#5a8a58"
+          "success": "#5a8a58",
+          "accent2": "#5888b0",
+          "overlay": "#b49683"
         },
         "hljs": {
           "keyword": "#b06090",
@@ -98,7 +100,9 @@
           "warning": "#a89030",
           "error": "#c05050",
           "info": "#2898a8",
-          "success": "#489070"
+          "success": "#489070",
+          "accent2": "#489070",
+          "overlay": "#839ca6"
         },
         "hljs": {
           "keyword": "#6868b0",
@@ -162,7 +166,9 @@
           "warning": "#c89828",
           "error": "#d04040",
           "info": "#3090b8",
-          "success": "#38a048"
+          "success": "#38a048",
+          "accent2": "#3090b8",
+          "overlay": "#809f78"
         },
         "hljs": {
           "keyword": "#e05880",
@@ -229,7 +235,9 @@
           "warning": "#c88820",
           "error": "#c04838",
           "info": "#4888b0",
-          "success": "#508a40"
+          "success": "#508a40",
+          "accent2": "#4888b0",
+          "overlay": "#ae9d7a"
         },
         "hljs": {
           "keyword": "#9060a0",
@@ -293,7 +301,9 @@
           "warning": "#d8b050",
           "error": "#e07070",
           "info": "#40b8c8",
-          "success": "#50c080"
+          "success": "#50c080",
+          "accent2": "#50c080",
+          "overlay": "#4e6480"
         },
         "hljs": {
           "keyword": "#d080b0",

--- a/plugins/tech-modern/manifest.json
+++ b/plugins/tech-modern/manifest.json
@@ -30,7 +30,9 @@
           "warning": "#fce100",
           "error": "#ff99a4",
           "info": "#60cdff",
-          "success": "#6ccb5f"
+          "success": "#6ccb5f",
+          "accent2": "#6ccb5f",
+          "overlay": "#5e5e5e"
         },
         "hljs": {
           "keyword": "#60cdff",
@@ -98,7 +100,9 @@
           "warning": "#e8a000",
           "error": "#d93025",
           "info": "#4285f4",
-          "success": "#1e8e3e"
+          "success": "#1e8e3e",
+          "accent2": "#1e8e3e",
+          "overlay": "#8997ac"
         },
         "hljs": {
           "keyword": "#d93025",
@@ -165,7 +169,9 @@
           "warning": "#ff9500",
           "error": "#ff3b30",
           "info": "#5856d6",
-          "success": "#34c759"
+          "success": "#34c759",
+          "accent2": "#5856d6",
+          "overlay": "#aaaaaf"
         },
         "hljs": {
           "keyword": "#007aff",
@@ -233,7 +239,9 @@
           "warning": "#c89030",
           "error": "#c44d5e",
           "info": "#5888b0",
-          "success": "#5a8a58"
+          "success": "#5a8a58",
+          "accent2": "#1a6dd2",
+          "overlay": "#b0a394"
         },
         "hljs": {
           "keyword": "#d97757",
@@ -297,7 +305,9 @@
           "warning": "#ff9900",
           "error": "#f05050",
           "info": "#48a8d8",
-          "success": "#48c078"
+          "success": "#48c078",
+          "accent2": "#48a8d8",
+          "overlay": "#65768c"
         },
         "hljs": {
           "keyword": "#ff9900",

--- a/plugins/winter-themes/manifest.json
+++ b/plugins/winter-themes/manifest.json
@@ -30,7 +30,9 @@
           "warning": "#b89040",
           "error": "#c85050",
           "info": "#5a8ab8",
-          "success": "#4a9068"
+          "success": "#4a9068",
+          "accent2": "#4a9068",
+          "overlay": "#8d9fb4"
         },
         "hljs": {
           "keyword": "#6070b0",
@@ -94,7 +96,9 @@
           "warning": "#a88a30",
           "error": "#b84a3a",
           "info": "#4a80a8",
-          "success": "#3d7a48"
+          "success": "#3d7a48",
+          "accent2": "#4a80a8",
+          "overlay": "#869a80"
         },
         "hljs": {
           "keyword": "#6a5898",
@@ -158,7 +162,9 @@
           "warning": "#e0c860",
           "error": "#e86080",
           "info": "#60a8d8",
-          "success": "#50d890"
+          "success": "#50d890",
+          "accent2": "#60c8e0",
+          "overlay": "#58667c"
         },
         "hljs": {
           "keyword": "#c880e0",
@@ -226,7 +232,9 @@
           "warning": "#aa8830",
           "error": "#bb5555",
           "info": "#5588bb",
-          "success": "#558866"
+          "success": "#558866",
+          "accent2": "#558866",
+          "overlay": "#9aa1a9"
         },
         "hljs": {
           "keyword": "#6868aa",
@@ -293,7 +301,9 @@
           "warning": "#d0b050",
           "error": "#d06070",
           "info": "#6090c0",
-          "success": "#60a878"
+          "success": "#60a878",
+          "accent2": "#60a878",
+          "overlay": "#58617c"
         },
         "hljs": {
           "keyword": "#a080c0",


### PR DESCRIPTION
## Summary
- Adds `accent2` and `overlay` to the `colors` block in all 30 themes across 7 Workshop packs (spring, winter, fall, neon, ocean, summer, tech-modern)
- Values sourced from zesty-iguana's spec posted to the shoulder-tap board
- No logic changes — pure data additions to manifest JSON files

## Test plan
- [ ] Verify each manifest parses as valid JSON
- [ ] Confirm `accent2` and `overlay` fields present in all 30 themes
- [ ] Validate against `ThemeColors` interface once warm-alpaca's type update (Clubhouse-side PR) lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)