### PR TITLE
fix(quality): Tier 0-1 safety fixes — CI injection hardening + SDK test harness

### DIFF
--- a/.github/workflows/release-batch.yml
+++ b/.github/workflows/release-batch.yml
@@ -135,10 +135,10 @@ jobs:
               echo "✓ $PLUGIN_ID v$VERSION built successfully"
               cat "/tmp/release-${PLUGIN_ID}.log" || true
               # Append to successes array using file-based accumulation
-              node -e "
+              BUILD_PLUGIN_ID="$PLUGIN_ID" node -e "
                 const fs = require('fs');
                 const s = JSON.parse(fs.readFileSync('/tmp/successful-builds.json', 'utf8'));
-                const r = JSON.parse(fs.readFileSync('/tmp/release-${PLUGIN_ID}.json', 'utf8'));
+                const r = JSON.parse(fs.readFileSync('/tmp/release-' + process.env.BUILD_PLUGIN_ID + '.json', 'utf8'));
                 s.push(r);
                 fs.writeFileSync('/tmp/successful-builds.json', JSON.stringify(s));
               "
@@ -146,10 +146,10 @@ jobs:
               echo "✗ $PLUGIN_ID v$VERSION FAILED"
               cat "/tmp/release-${PLUGIN_ID}.log" || true
               cat "/tmp/release-${PLUGIN_ID}.json" || true
-              node -e "
+              BUILD_PLUGIN_ID="$PLUGIN_ID" BUILD_VERSION="$VERSION" node -e "
                 const fs = require('fs');
                 const f = JSON.parse(fs.readFileSync('/tmp/failed-builds.json', 'utf8'));
-                f.push({pluginId:'$PLUGIN_ID',version:'$VERSION',error:'Build/validation failed'});
+                f.push({pluginId:process.env.BUILD_PLUGIN_ID,version:process.env.BUILD_VERSION,error:'Build/validation failed'});
                 fs.writeFileSync('/tmp/failed-builds.json', JSON.stringify(f));
               "
             fi
@@ -190,7 +190,7 @@ jobs:
         run: |
           node -e "
             const fs = require('fs');
-            const { execSync } = require('child_process');
+            const { execFileSync } = require('child_process');
             const builds = JSON.parse(fs.readFileSync('/tmp/successful-builds.json', 'utf8'));
 
             for (const build of builds) {
@@ -199,13 +199,12 @@ jobs:
                 '### Install\n\`\`\`bash\ncp -r plugins/' + build.pluginId + ' ~/.clubhouse/plugins/\n\`\`\`\n\n' +
                 'Or download the zip and extract to \`~/.clubhouse/plugins/' + build.pluginId + '/\`.';
 
-              execSync(
-                'gh release create ' + build.tag +
-                ' ' + build.zipPath +
-                ' --title \"' + build.pluginId + ' v' + build.version + '\"' +
-                ' --notes \"' + body.replace(/\"/g, '\\\\\"') + '\"',
-                { stdio: 'inherit' }
-              );
+              execFileSync('gh', [
+                'release', 'create', build.tag,
+                build.zipPath,
+                '--title', build.pluginId + ' v' + build.version,
+                '--notes', body
+              ], { stdio: 'inherit' });
               console.log('✓ Release created: ' + build.tag);
             }
           "

--- a/sdk/v0.6/plugin-testing/src/test-harness.ts
+++ b/sdk/v0.6/plugin-testing/src/test-harness.ts
@@ -2,11 +2,17 @@ import type { PluginModule, PluginAPI, PluginContext } from "@clubhouse/plugin-t
 import { createMockAPI } from "./mock-api";
 import { createMockContext } from "./mock-context";
 
+type PanelName = "MainPanel" | "SidebarPanel" | "HubPanel" | "SettingsPanel";
+
 interface RenderPluginOptions {
   pluginId?: string;
   projectId?: string;
   projectPath?: string;
   apiOverrides?: Parameters<typeof createMockAPI>[0];
+  /** Which panel to render (default: "MainPanel"). */
+  panel?: PanelName;
+  /** Props forwarded to HubPanel (paneId, resourceId). */
+  hubPanelProps?: { paneId?: string; resourceId?: string };
 }
 
 interface RenderResult {
@@ -58,11 +64,18 @@ export async function renderPlugin(
     await module.activate(ctx, api);
   }
 
-  // Render MainPanel if it exists — panels receive { api } only
+  // Render the requested panel (default: MainPanel)
   let element: RenderResult["element"] = null;
-  if (module.MainPanel) {
-    const Panel = module.MainPanel as (props: { api: PluginAPI }) => React.ReactNode;
-    element = Panel({ api });
+  const panelName = options?.panel ?? "MainPanel";
+
+  if (panelName === "HubPanel" && module.HubPanel) {
+    const Panel = module.HubPanel as (props: { paneId: string; resourceId?: string }) => React.ReactNode;
+    element = Panel({ paneId: options?.hubPanelProps?.paneId ?? "test-pane", resourceId: options?.hubPanelProps?.resourceId });
+  } else {
+    const Panel = module[panelName] as ((props: { api: PluginAPI }) => React.ReactNode) | undefined;
+    if (Panel) {
+      element = Panel({ api });
+    }
   }
 
   // Cleanup function

--- a/sdk/v0.7/plugin-testing/src/test-harness.ts
+++ b/sdk/v0.7/plugin-testing/src/test-harness.ts
@@ -2,11 +2,17 @@ import type { PluginModule, PluginAPI, PluginContext } from "@clubhouse/plugin-t
 import { createMockAPI } from "./mock-api";
 import { createMockContext } from "./mock-context";
 
+type PanelName = "MainPanel" | "SidebarPanel" | "HubPanel" | "SettingsPanel" | "DialogPanel";
+
 interface RenderPluginOptions {
   pluginId?: string;
   projectId?: string;
   projectPath?: string;
   apiOverrides?: Parameters<typeof createMockAPI>[0];
+  /** Which panel to render (default: "MainPanel"). */
+  panel?: PanelName;
+  /** Props forwarded to HubPanel (paneId, resourceId). */
+  hubPanelProps?: { paneId?: string; resourceId?: string };
 }
 
 interface RenderResult {
@@ -58,11 +64,21 @@ export async function renderPlugin(
     await module.activate(ctx, api);
   }
 
-  // Render MainPanel if it exists — panels receive { api } only
+  // Render the requested panel (default: MainPanel)
   let element: RenderResult["element"] = null;
-  if (module.MainPanel) {
-    const Panel = module.MainPanel as (props: { api: PluginAPI }) => React.ReactNode;
-    element = Panel({ api });
+  const panelName = options?.panel ?? "MainPanel";
+
+  if (panelName === "HubPanel" && module.HubPanel) {
+    const Panel = module.HubPanel as (props: { paneId: string; resourceId?: string }) => React.ReactNode;
+    element = Panel({ paneId: options?.hubPanelProps?.paneId ?? "test-pane", resourceId: options?.hubPanelProps?.resourceId });
+  } else if (panelName === "DialogPanel" && module.DialogPanel) {
+    const Panel = module.DialogPanel as (props: { api: PluginAPI; onClose: () => void }) => React.ReactNode;
+    element = Panel({ api, onClose: () => {} });
+  } else {
+    const Panel = module[panelName] as ((props: { api: PluginAPI }) => React.ReactNode) | undefined;
+    if (Panel) {
+      element = Panel({ api });
+    }
   }
 
   // Cleanup function


### PR DESCRIPTION
## Summary
- **QS-001**: Hardened `release-batch.yml` against command injection — replaced shell variable interpolation in `node -e` strings with `process.env` references, replaced `execSync` string concatenation with `execFileSync` array args
- **QS-008**: Extended SDK test harness (`v0.6` + `v0.7`) to support all panel types — `renderPlugin()` now accepts a `panel` option for `SidebarPanel`, `HubPanel`, `SettingsPanel`, and `DialogPanel`

### Already Remediated (verified, no changes needed)
| Item | Status | Evidence |
|------|--------|----------|
| QS-002 (registry auto-merge) | Fixed | Both workflows create PRs, no auto-merge |
| QS-003 (onAgentCompleted race) | Fixed | completionChain serialization + .catch() |
| QS-004 (automations storage) | Fixed | Serialized with try/catch |
| QS-005 (cron reentrancy) | Fixed | cronRunning guard |
| QS-006 (scaffolder API 0.5) | Fixed | Targets API 0.7 |
| QS-007 (isMain guard) | Fixed | Both validation scripts have isMain guard |
| QS-009 (AutomationEngine tests) | Fixed | 31 tests, 913 lines |
| QS-012 (toId() guard) | Fixed | Throws on empty string |
| QS-013 (WikiViewer useEffect) | Fixed | Proper dependencies, no eslint-disable |

## Test plan
- [x] kanboss: 201 tests pass (12 files)
- [x] SDK v0.6 plugin-testing: type-check clean
- [x] SDK v0.7 plugin-testing: type-check clean
- [x] create-clubhouse-plugin: 26 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)