### PR TITLE
feat: Lounge plugin — agent browser with circles, avatars, tags & resizable sidebar

### DIFF
--- a/plugins/lounge/.gitignore
+++ b/plugins/lounge/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/plugins/lounge/README.md
+++ b/plugins/lounge/README.md
@@ -1,0 +1,50 @@
+# Lounge
+
+A Teams-style agent browser for [Clubhouse](https://github.com/Agent-Clubhouse/Clubhouse). Browse and manage AI agents across all projects from a single sidebar, organized into customizable circles.
+
+## Features
+
+- **Agent browser sidebar** — agents grouped by project with inline content view
+- **Custom circles** — create, rename, and delete categories with emoji icons
+- **Drag-and-drop** — move agents between circles and reorder circles
+- **Context menus** — right-click agents to move them, right-click circles to rename/delete
+- **Persistent config** — circle assignments, emojis, and order saved across sessions
+- **Smart grouping** — auto-groups by project, hides empty project categories, auto-deletes empty custom circles
+
+## Install
+
+Copy the plugin to your Clubhouse plugins directory:
+
+```bash
+cp -r plugins/lounge ~/.clubhouse/plugins/
+```
+
+Or symlink for development:
+
+```bash
+ln -s "$(pwd)/plugins/lounge" ~/.clubhouse/plugins/lounge
+```
+
+Then enable it in **Settings → Plugins**.
+
+## Development
+
+```bash
+cd plugins/lounge
+npm install
+npm run build       # Build dist/main.js
+npm run watch       # Rebuild on changes
+npm run typecheck   # Type-check with tsc
+npm test            # Run tests
+```
+
+## Permissions
+
+| Permission | Why |
+|---|---|
+| `agents` | List agents across all projects |
+| `projects` | Access project metadata for grouping |
+| `navigation` | Navigate to agents when selected |
+| `widgets` | Render shared UI components |
+| `commands` | Register command palette entries |
+| `storage` | Persist circle configuration globally |

--- a/plugins/lounge/build.cjs
+++ b/plugins/lounge/build.cjs
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+const esbuild = require('esbuild');
+const path = require('path');
+
+const watch = process.argv.includes('--watch');
+
+const buildOptions = {
+  entryPoints: [path.join(__dirname, 'src', 'main.ts')],
+  bundle: true,
+  format: 'esm',
+  platform: 'browser',
+  target: 'es2022',
+  external: ['react', 'react/jsx-runtime'],
+  outfile: path.join(__dirname, 'dist', 'main.js'),
+  // Force ESM resolution for zustand to avoid CJS require('react') at runtime
+  conditions: ['import', 'module', 'browser'],
+};
+
+async function run() {
+  if (watch) {
+    const ctx = await esbuild.context(buildOptions);
+    await ctx.watch();
+    console.log('Watching for changes...');
+  } else {
+    await esbuild.build(buildOptions);
+    console.log(`✓ Built → ${buildOptions.outfile}`);
+  }
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/plugins/lounge/dist/main.js
+++ b/plugins/lounge/dist/main.js
@@ -70,6 +70,7 @@ function getPersistedState(state) {
     nextCircleId: state.nextCircleId,
     categoryOrder: state.categoryOrder,
     categoryEmojis: state.categoryEmojis,
+    agentOrder: state.agentOrder,
     collapsed: Array.from(state.collapsed)
   };
 }
@@ -95,6 +96,21 @@ function groupAgentsByCategory(agents, categories, overrides = {}) {
     }
   }
   return groups;
+}
+function sortAgentsByOrder(agents, order) {
+  if (!order || order.length === 0) return agents;
+  const posMap = new Map(order.map((id, i) => [id, i]));
+  const ordered = [];
+  const unordered = [];
+  for (const agent of agents) {
+    if (posMap.has(agent.id)) {
+      ordered.push(agent);
+    } else {
+      unordered.push(agent);
+    }
+  }
+  ordered.sort((a, b) => posMap.get(a.id) - posMap.get(b.id));
+  return [...ordered, ...unordered];
 }
 function disambiguateAgentName(agent, allAgents, projects) {
   const sameNameAgents = allAgents.filter((a) => a.name === agent.name);
@@ -137,6 +153,7 @@ var createLoungeStore = () => create((set, get) => ({
   nextCircleId: 1,
   categoryOrder: [],
   categoryEmojis: {},
+  agentOrder: {},
   hydrated: false,
   deriveCategories(projects) {
     set((state) => {
@@ -201,9 +218,52 @@ var createLoungeStore = () => create((set, get) => ({
   },
   moveAgent(agentId, targetCategoryId) {
     if (!get().hydrated) return;
-    set((state) => ({
-      agentCategoryOverrides: { ...state.agentCategoryOverrides, [agentId]: targetCategoryId }
-    }));
+    set((state) => {
+      const newAgentOrder = { ...state.agentOrder };
+      for (const [catId, order] of Object.entries(newAgentOrder)) {
+        if (order.includes(agentId)) {
+          newAgentOrder[catId] = order.filter((id) => id !== agentId);
+        }
+      }
+      const targetOrder = newAgentOrder[targetCategoryId] ?? [];
+      newAgentOrder[targetCategoryId] = [...targetOrder, agentId];
+      return {
+        agentCategoryOverrides: { ...state.agentCategoryOverrides, [agentId]: targetCategoryId },
+        agentOrder: newAgentOrder
+      };
+    });
+  },
+  placeAgent(agentId, targetCategoryId, beforeAgentId, currentAgentIds) {
+    if (!get().hydrated) return;
+    set((state) => {
+      const newAgentOrder = { ...state.agentOrder };
+      for (const [catId, order] of Object.entries(newAgentOrder)) {
+        if (order.includes(agentId)) {
+          newAgentOrder[catId] = order.filter((id) => id !== agentId);
+        }
+      }
+      let targetOrder;
+      if (currentAgentIds) {
+        targetOrder = currentAgentIds.filter((id) => id !== agentId);
+      } else {
+        targetOrder = [...newAgentOrder[targetCategoryId] ?? []];
+      }
+      if (beforeAgentId) {
+        const idx = targetOrder.indexOf(beforeAgentId);
+        if (idx >= 0) {
+          targetOrder.splice(idx, 0, agentId);
+        } else {
+          targetOrder.push(agentId);
+        }
+      } else {
+        targetOrder.push(agentId);
+      }
+      newAgentOrder[targetCategoryId] = targetOrder;
+      return {
+        agentCategoryOverrides: { ...state.agentCategoryOverrides, [agentId]: targetCategoryId },
+        agentOrder: newAgentOrder
+      };
+    });
   },
   addCircle(label) {
     if (!label.trim()) return "";
@@ -239,6 +299,7 @@ var createLoungeStore = () => create((set, get) => ({
       const newOrder = state.categoryOrder.filter((id) => id !== circleId);
       const { [circleId]: _emoji, ...newEmojis } = state.categoryEmojis;
       const { [circleId]: _label, ...newLabels } = state.renamedLabels;
+      const { [circleId]: _agentOrder, ...newAgentOrder } = state.agentOrder;
       const newCollapsed = new Set(state.collapsed);
       newCollapsed.delete(circleId);
       return {
@@ -248,6 +309,7 @@ var createLoungeStore = () => create((set, get) => ({
         categoryOrder: newOrder,
         categoryEmojis: newEmojis,
         renamedLabels: newLabels,
+        agentOrder: newAgentOrder,
         collapsed: newCollapsed
       };
     });
@@ -292,6 +354,7 @@ var createLoungeStore = () => create((set, get) => ({
       nextCircleId: data.nextCircleId ?? 1,
       categoryOrder: data.categoryOrder ?? [],
       categoryEmojis: data.categoryEmojis ?? {},
+      agentOrder: data.agentOrder ?? {},
       collapsed: new Set(data.collapsed ?? []),
       hydrated: true
     });
@@ -449,7 +512,7 @@ function CategoryContextMenu({ position, categoryId, onRename, onDelete, onClose
     )
   );
 }
-function AgentContextMenu({ position, categories, currentCategoryId, onMoveTo, onCreateCircle, onClose }) {
+function AgentContextMenu({ position, agent, api, categories, currentCategoryId, onMoveTo, onCreateCircle, onClose }) {
   const menuRef = useRef(null);
   const [showSubmenu, setShowSubmenu] = useState(false);
   const moveToRef = useRef(null);
@@ -484,6 +547,9 @@ function AgentContextMenu({ position, categories, currentCategoryId, onMoveTo, o
     const y = Math.min(0, window.innerHeight - rect.top - submenuHeight - 8);
     return { left: x, top: y };
   }, [showSubmenu, categories.length]);
+  const isRunning = agent.status === "running" || agent.status === "waking" || agent.status === "creating";
+  const isSleeping = agent.status === "sleeping";
+  const menuItemClass = "w-full flex items-center gap-2 px-3 py-1.5 text-xs text-ctp-subtext0 hover:bg-surface-1 hover:text-ctp-text transition-colors cursor-pointer";
   return React2.createElement(
     "div",
     {
@@ -492,6 +558,85 @@ function AgentContextMenu({ position, categories, currentCategoryId, onMoveTo, o
       style,
       "data-testid": "lounge-agent-context-menu"
     },
+    // ── Agent lifecycle actions ──
+    isRunning && React2.createElement(
+      "button",
+      {
+        className: menuItemClass,
+        onClick: () => {
+          api.agents.kill(agent.id).catch(() => {
+          });
+          onClose();
+        },
+        "data-testid": "lounge-ctx-stop"
+      },
+      React2.createElement("svg", {
+        width: 12,
+        height: 12,
+        viewBox: "0 0 24 24",
+        fill: "none",
+        stroke: "currentColor",
+        strokeWidth: 2,
+        strokeLinecap: "round",
+        strokeLinejoin: "round"
+      }, React2.createElement("rect", { x: "6", y: "6", width: "12", height: "12", rx: "1" })),
+      React2.createElement("span", null, "Stop")
+    ),
+    isSleeping && React2.createElement(
+      "button",
+      {
+        className: menuItemClass,
+        onClick: () => {
+          api.agents.resume(agent.id).catch(() => {
+          });
+          onClose();
+        },
+        "data-testid": "lounge-ctx-wake"
+      },
+      React2.createElement("svg", {
+        width: 12,
+        height: 12,
+        viewBox: "0 0 24 24",
+        fill: "none",
+        stroke: "currentColor",
+        strokeWidth: 2,
+        strokeLinecap: "round",
+        strokeLinejoin: "round"
+      }, React2.createElement("polygon", { points: "5 3 19 12 5 21 5 3" })),
+      React2.createElement("span", null, "Wake")
+    ),
+    // Pop Out
+    React2.createElement(
+      "button",
+      {
+        className: menuItemClass,
+        onClick: () => {
+          api.navigation.popOutAgent(agent.id).catch(() => {
+          });
+          onClose();
+        },
+        "data-testid": "lounge-ctx-popout"
+      },
+      React2.createElement(
+        "svg",
+        {
+          width: 12,
+          height: 12,
+          viewBox: "0 0 24 24",
+          fill: "none",
+          stroke: "currentColor",
+          strokeWidth: 2,
+          strokeLinecap: "round",
+          strokeLinejoin: "round"
+        },
+        React2.createElement("path", { d: "M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" }),
+        React2.createElement("polyline", { points: "15 3 21 3 21 9" }),
+        React2.createElement("line", { x1: "10", y1: "14", x2: "21", y2: "3" })
+      ),
+      React2.createElement("span", null, "Pop Out")
+    ),
+    // Divider between lifecycle and circle actions
+    React2.createElement("div", { className: "mx-2 my-1 border-t border-surface-1" }),
     // "Move to" with submenu
     React2.createElement(
       "div",
@@ -764,7 +909,7 @@ function CircleDialog({ mode, onConfirm, onCancel, existingCategories, initialNa
     )
   );
 }
-function CategorySection({ category, agents, allAgents, allCategories, projects, isCollapsed, selectedAgentId, onToggle, onSelectAgent, onEditCircle, onDelete, onMoveAgent, onCreateCircle, onReorderCategory }) {
+function CategorySection({ category, agents, allAgents, allCategories, projects, isCollapsed, selectedAgentId, api, onToggle, onSelectAgent, onEditCircle, onDelete, onMoveAgent, onPlaceAgent, onCreateCircle, onReorderCategory }) {
   const [contextMenu, setContextMenu] = useState(null);
   const [agentContextMenu, setAgentContextMenu] = useState(null);
   const [dragOver, setDragOver] = useState(false);
@@ -799,14 +944,14 @@ function CategorySection({ category, agents, allAgents, allCategories, projects,
     setDragOver(false);
     const agentId = e.dataTransfer.getData("application/x-lounge-agent");
     if (agentId) {
-      onMoveAgent(agentId, category.id);
+      onPlaceAgent(agentId, category.id, null, agents.map((a) => a.id));
       return;
     }
     const fromCategoryId = e.dataTransfer.getData("application/x-lounge-category");
     if (fromCategoryId && fromCategoryId !== category.id && !isGeneralCircle) {
       onReorderCategory(fromCategoryId, category.id);
     }
-  }, [category.id, onMoveAgent, onReorderCategory, isGeneralCircle]);
+  }, [category.id, onPlaceAgent, onReorderCategory, isGeneralCircle]);
   return React2.createElement(
     "div",
     {
@@ -843,33 +988,61 @@ function CategorySection({ category, agents, allAgents, allCategories, projects,
       onClose: () => setContextMenu(null)
     }),
     // Agent rows (hidden when collapsed)
-    !isCollapsed && agents.length > 0 && agents.map((agent) => {
+    !isCollapsed && agents.length > 0 && agents.map((agent, idx) => {
       const displayName = disambiguateAgentName(agent, allAgents, projects);
-      return React2.createElement(AgentRow, {
-        key: agent.id,
-        agent,
-        displayName,
-        isSelected: selectedAgentId === agent.id,
-        onClick: () => onSelectAgent(agent.id, agent.projectId),
-        onContextMenu: (e) => {
-          e.preventDefault();
-          setAgentContextMenu({ agentId: agent.id, x: e.clientX, y: e.clientY });
-        }
-      });
+      const nextAgentId = idx < agents.length - 1 ? agents[idx + 1].id : null;
+      return React2.createElement(
+        "div",
+        {
+          key: agent.id,
+          onDragOver: (e) => {
+            if (!e.dataTransfer.types.includes("application/x-lounge-agent")) return;
+            e.preventDefault();
+            e.stopPropagation();
+            e.dataTransfer.dropEffect = "move";
+          },
+          onDrop: (e) => {
+            const draggedId = e.dataTransfer.getData("application/x-lounge-agent");
+            if (!draggedId || draggedId === agent.id) return;
+            e.preventDefault();
+            e.stopPropagation();
+            const rect = e.currentTarget.getBoundingClientRect();
+            const isUpperHalf = e.clientY < rect.top + rect.height / 2;
+            const beforeId = isUpperHalf ? agent.id : nextAgentId;
+            onPlaceAgent(draggedId, category.id, beforeId, agents.map((a) => a.id));
+          }
+        },
+        React2.createElement(AgentRow, {
+          agent,
+          displayName,
+          isSelected: selectedAgentId === agent.id,
+          onClick: () => onSelectAgent(agent.id, agent.projectId),
+          onContextMenu: (e) => {
+            e.preventDefault();
+            setAgentContextMenu({ agentId: agent.id, x: e.clientX, y: e.clientY });
+          }
+        })
+      );
     }),
     // Empty custom circle hint
     !isCollapsed && agents.length === 0 && React2.createElement("div", {
       className: "px-8 py-2 text-[11px] text-ctp-overlay0 italic"
     }, "Move agents here via right-click"),
     // Agent context menu
-    agentContextMenu && React2.createElement(AgentContextMenu, {
-      position: agentContextMenu,
-      categories: allCategories,
-      currentCategoryId: category.id,
-      onMoveTo: (targetCategoryId) => onMoveAgent(agentContextMenu.agentId, targetCategoryId),
-      onCreateCircle: () => onCreateCircle(agentContextMenu.agentId),
-      onClose: () => setAgentContextMenu(null)
-    })
+    agentContextMenu && (() => {
+      const ctxAgent = agents.find((a) => a.id === agentContextMenu.agentId) ?? allAgents.find((a) => a.id === agentContextMenu.agentId);
+      if (!ctxAgent) return null;
+      return React2.createElement(AgentContextMenu, {
+        position: agentContextMenu,
+        agent: ctxAgent,
+        api,
+        categories: allCategories,
+        currentCategoryId: category.id,
+        onMoveTo: (targetCategoryId) => onMoveAgent(agentContextMenu.agentId, targetCategoryId),
+        onCreateCircle: () => onCreateCircle(agentContextMenu.agentId),
+        onClose: () => setAgentContextMenu(null)
+      });
+    })()
   );
 }
 function EmptyState() {
@@ -929,6 +1102,8 @@ function MainPanel({ api }) {
   const deleteCircle = useLoungeStore((s) => s.deleteCircle);
   const reorderCategory = useLoungeStore((s) => s.reorderCategory);
   const setCategoryEmoji = useLoungeStore((s) => s.setCategoryEmoji);
+  const placeAgent = useLoungeStore((s) => s.placeAgent);
+  const agentOrder = useLoungeStore((s) => s.agentOrder);
   const loadPersistedState = useLoungeStore((s) => s.loadPersistedState);
   const [loaded, setLoaded] = useState(false);
   useEffect(() => {
@@ -963,7 +1138,7 @@ function MainPanel({ api }) {
         });
       }
     };
-  }, [api, loaded, renamedLabels, agentCategoryOverrides, customCircles, nextCircleId, categoryOrder, categoryEmojis, collapsed]);
+  }, [api, loaded, renamedLabels, agentCategoryOverrides, customCircles, nextCircleId, categoryOrder, categoryEmojis, agentOrder, collapsed]);
   const [agentTick, setAgentTick] = useState(0);
   useEffect(() => {
     const sub = api.agents.onAnyChange(() => setAgentTick((n) => n + 1));
@@ -971,8 +1146,9 @@ function MainPanel({ api }) {
   }, [api]);
   const projects = useMemo(() => api.projects.list(), [api, agentTick]);
   useEffect(() => {
+    if (!loaded) return;
     deriveCategories(projects);
-  }, [projects, deriveCategories]);
+  }, [projects, deriveCategories, loaded]);
   const agents = useMemo(() => api.agents.list(), [api, agentTick]);
   const grouped = useMemo(
     () => groupAgentsByCategory(agents, categories, agentCategoryOverrides),
@@ -1071,7 +1247,7 @@ function MainPanel({ api }) {
           "data-testid": "lounge-category-list"
         },
         hasAgents || categories.some((c) => !c.projectId) ? visibleCategories.map((cat) => {
-          const catAgents = grouped.get(cat.id) ?? [];
+          const catAgents = sortAgentsByOrder(grouped.get(cat.id) ?? [], agentOrder[cat.id]);
           return React2.createElement(CategorySection, {
             key: cat.id,
             category: cat,
@@ -1081,11 +1257,13 @@ function MainPanel({ api }) {
             projects,
             isCollapsed: collapsed.has(cat.id),
             selectedAgentId,
+            api,
             onToggle: () => toggleCollapsed(cat.id),
             onSelectAgent: handleSelectAgent,
             onEditCircle: handleEditCircle,
             onDelete: deleteCircle,
             onMoveAgent: moveAgent,
+            onPlaceAgent: placeAgent,
             onCreateCircle: handleCreateCircle,
             onReorderCategory: reorderCategory
           });

--- a/plugins/lounge/dist/main.js
+++ b/plugins/lounge/dist/main.js
@@ -974,7 +974,14 @@ function CategorySection({ category, agents, allAgents, allCategories, projects,
       isCollapsed ? CHEVRON_RIGHT : CHEVRON_DOWN,
       React2.createElement("span", { className: "text-sm flex-shrink-0" }, category.emoji || "\u{1F4C1}"),
       React2.createElement("span", { className: "flex-1 text-left truncate" }, category.label),
-      React2.createElement("span", { className: "text-[10px] text-ctp-overlay0 tabular-nums" }, String(agents.length))
+      React2.createElement(
+        "span",
+        { className: "text-[10px] text-ctp-overlay0 tabular-nums" },
+        (() => {
+          const active = agents.filter((a) => a.status === "running" || a.status === "waking" || a.status === "creating").length;
+          return active > 0 ? `${active}/${agents.length}` : String(agents.length);
+        })()
+      )
     ),
     // Context menu
     contextMenu && React2.createElement(CategoryContextMenu, {

--- a/plugins/lounge/dist/main.js
+++ b/plugins/lounge/dist/main.js
@@ -1069,6 +1069,18 @@ function EmptyState() {
 function AgentContent({ api, agentId }) {
   const agents = api.agents.list();
   const agent = agents.find((a) => a.id === agentId);
+  const [terminalFocused, setTerminalFocused] = useState(false);
+  const prevAgentIdRef = useRef(agentId);
+  useEffect(() => {
+    const agentChanged = prevAgentIdRef.current !== agentId;
+    prevAgentIdRef.current = agentId;
+    if (agentChanged) {
+      setTerminalFocused(false);
+      const raf = requestAnimationFrame(() => setTerminalFocused(true));
+      return () => cancelAnimationFrame(raf);
+    }
+    setTerminalFocused(true);
+  }, [agentId]);
   if (!agent) {
     return React2.createElement("div", {
       className: "flex items-center justify-center h-full text-ctp-subtext0 text-sm"
@@ -1078,7 +1090,7 @@ function AgentContent({ api, agentId }) {
   if (agent.status === "sleeping" || agent.status === "error") {
     return React2.createElement(SleepingAgent, { agentId: agent.id });
   }
-  return React2.createElement(AgentTerminal, { agentId: agent.id, focused: true });
+  return React2.createElement(AgentTerminal, { agentId: agent.id, focused: terminalFocused });
 }
 function NoSelection() {
   return React2.createElement(

--- a/plugins/lounge/dist/main.js
+++ b/plugins/lounge/dist/main.js
@@ -71,7 +71,10 @@ function getPersistedState(state) {
     categoryOrder: state.categoryOrder,
     categoryEmojis: state.categoryEmojis,
     agentOrder: state.agentOrder,
-    collapsed: Array.from(state.collapsed)
+    collapsed: Array.from(state.collapsed),
+    showTags: state.showTags,
+    sidebarCollapsed: state.sidebarCollapsed,
+    sidebarWidth: state.sidebarWidth
   };
 }
 function groupAgentsByCategory(agents, categories, overrides = {}) {
@@ -155,6 +158,9 @@ var createLoungeStore = () => create((set, get) => ({
   categoryEmojis: {},
   agentOrder: {},
   hydrated: false,
+  showTags: true,
+  sidebarCollapsed: false,
+  sidebarWidth: 256,
   deriveCategories(projects) {
     set((state) => {
       const projectCategories = projects.map((p) => {
@@ -346,6 +352,16 @@ var createLoungeStore = () => create((set, get) => ({
       return { categoryEmojis: newEmojis, categories: newCategories, customCircles: newCustomCircles };
     });
   },
+  toggleShowTags() {
+    set((state) => ({ showTags: !state.showTags }));
+  },
+  toggleSidebar() {
+    set((state) => ({ sidebarCollapsed: !state.sidebarCollapsed }));
+  },
+  setSidebarWidth(width) {
+    const clamped = Math.max(160, Math.min(480, width));
+    set({ sidebarWidth: clamped });
+  },
   loadPersistedState(data) {
     set({
       renamedLabels: data.renamedLabels ?? {},
@@ -356,10 +372,63 @@ var createLoungeStore = () => create((set, get) => ({
       categoryEmojis: data.categoryEmojis ?? {},
       agentOrder: data.agentOrder ?? {},
       collapsed: new Set(data.collapsed ?? []),
+      showTags: data.showTags ?? true,
+      sidebarCollapsed: data.sidebarCollapsed ?? false,
+      sidebarWidth: data.sidebarWidth ?? 256,
       hydrated: true
     });
   }
 }));
+
+// src/tag-helpers.ts
+var ORCHESTRATOR_COLORS = {
+  "claude-code": { bg: "rgba(249,115,22,0.2)", text: "#fb923c" },
+  "copilot-cli": { bg: "rgba(59,130,246,0.2)", text: "#60a5fa" }
+};
+var DEFAULT_ORCH_COLOR = { bg: "rgba(148,163,184,0.2)", text: "#94a3b8" };
+function getOrchestratorColor(id) {
+  return ORCHESTRATOR_COLORS[id] || DEFAULT_ORCH_COLOR;
+}
+var ORCHESTRATOR_DISPLAY_NAMES = {
+  "claude-code": "CC",
+  "copilot-cli": "GHCP",
+  "codex-cli": "Codex"
+};
+function getOrchestratorLabel(orchId, allOrchestrators) {
+  const info = allOrchestrators?.find((o) => o.id === orchId);
+  if (info) return info.shortName || info.displayName || orchId;
+  return ORCHESTRATOR_DISPLAY_NAMES[orchId] || orchId;
+}
+var MODEL_PALETTE = [
+  { bg: "rgba(168,85,247,0.2)", text: "#c084fc" },
+  { bg: "rgba(20,184,166,0.2)", text: "#2dd4bf" },
+  { bg: "rgba(236,72,153,0.2)", text: "#f472b6" },
+  { bg: "rgba(34,197,94,0.2)", text: "#4ade80" },
+  { bg: "rgba(251,191,36,0.2)", text: "#fbbf24" },
+  { bg: "rgba(99,102,241,0.2)", text: "#818cf8" },
+  { bg: "rgba(14,165,233,0.2)", text: "#38bdf8" }
+];
+var DEFAULT_MODEL_COLOR = { bg: "rgba(148,163,184,0.15)", text: "#94a3b8" };
+var modelColorCache = /* @__PURE__ */ new Map();
+function getModelColor(model) {
+  let color = modelColorCache.get(model);
+  if (!color) {
+    let hash = 0;
+    for (let i = 0; i < model.length; i++) hash = hash * 31 + model.charCodeAt(i) | 0;
+    color = MODEL_PALETTE[(hash % MODEL_PALETTE.length + MODEL_PALETTE.length) % MODEL_PALETTE.length];
+    modelColorCache.set(model, color);
+  }
+  return color;
+}
+function formatModelLabel(model) {
+  if (!model || model === "default") return "Default";
+  return model.charAt(0).toUpperCase() + model.slice(1);
+}
+var FREE_AGENT_COLOR = { bg: "rgba(239,68,68,0.15)", text: "#f87171" };
+function getModelTagColor(model) {
+  if (!model || model === "default") return DEFAULT_MODEL_COLOR;
+  return getModelColor(model);
+}
 
 // src/main.ts
 var useLoungeStore = createLoungeStore();
@@ -396,7 +465,7 @@ function statusLabel(status) {
       return status;
   }
 }
-function AgentRow({ agent, displayName, isSelected, onClick, onContextMenu }) {
+function AgentRow({ agent, displayName, isSelected, showTags, orchestrators, onClick, onContextMenu }) {
   const handleDragStart = useCallback((e) => {
     e.dataTransfer.setData("application/x-lounge-agent", agent.id);
     e.dataTransfer.effectAllowed = "move";
@@ -416,7 +485,40 @@ function AgentRow({ agent, displayName, isSelected, onClick, onContextMenu }) {
     React2.createElement("span", {
       className: `w-2 h-2 rounded-full flex-shrink-0 ${statusColor(agent.status)}`
     }),
-    React2.createElement("span", { className: "truncate flex-1" }, displayName),
+    React2.createElement(
+      "div",
+      { className: "min-w-0 flex-1" },
+      React2.createElement("span", { className: "truncate block" }, displayName),
+      showTags && React2.createElement(
+        "div",
+        {
+          className: "flex items-center gap-1 mt-0.5 flex-wrap",
+          "data-testid": `lounge-agent-tags-${agent.id}`
+        },
+        // Provider tag
+        agent.orchestrator && (() => {
+          const c = getOrchestratorColor(agent.orchestrator);
+          return React2.createElement("span", {
+            style: { backgroundColor: c.bg, color: c.text, fontSize: "10px", padding: "1px 6px", borderRadius: "4px", lineHeight: "16px", whiteSpace: "nowrap" },
+            "data-testid": "lounge-tag-provider"
+          }, getOrchestratorLabel(agent.orchestrator, orchestrators));
+        })(),
+        // Model tag
+        (() => {
+          const label = formatModelLabel(agent.model);
+          const c = getModelTagColor(agent.model);
+          return React2.createElement("span", {
+            style: { backgroundColor: c.bg, color: c.text, fontSize: "10px", padding: "1px 6px", borderRadius: "4px", lineHeight: "16px", fontFamily: "monospace", whiteSpace: "nowrap" },
+            "data-testid": "lounge-tag-model"
+          }, label);
+        })(),
+        // Free Agent tag
+        agent.freeAgentMode && React2.createElement("span", {
+          style: { backgroundColor: FREE_AGENT_COLOR.bg, color: FREE_AGENT_COLOR.text, fontSize: "10px", padding: "1px 6px", borderRadius: "4px", lineHeight: "16px", whiteSpace: "nowrap" },
+          "data-testid": "lounge-tag-free"
+        }, "Free")
+      )
+    ),
     agent.status === "running" && React2.createElement("span", {
       className: "text-[10px] text-ctp-green flex-shrink-0"
     }, "\u25CF")
@@ -909,7 +1011,7 @@ function CircleDialog({ mode, onConfirm, onCancel, existingCategories, initialNa
     )
   );
 }
-function CategorySection({ category, agents, allAgents, allCategories, projects, isCollapsed, selectedAgentId, api, onToggle, onSelectAgent, onEditCircle, onDelete, onMoveAgent, onPlaceAgent, onCreateCircle, onReorderCategory }) {
+function CategorySection({ category, agents, allAgents, allCategories, projects, isCollapsed, selectedAgentId, showTags, orchestrators, api, onToggle, onSelectAgent, onEditCircle, onDelete, onMoveAgent, onPlaceAgent, onCreateCircle, onReorderCategory }) {
   const [contextMenu, setContextMenu] = useState(null);
   const [agentContextMenu, setAgentContextMenu] = useState(null);
   const [dragOver, setDragOver] = useState(false);
@@ -1023,6 +1125,8 @@ function CategorySection({ category, agents, allAgents, allCategories, projects,
           agent,
           displayName,
           isSelected: selectedAgentId === agent.id,
+          showTags,
+          orchestrators,
           onClick: () => onSelectAgent(agent.id, agent.projectId),
           onContextMenu: (e) => {
             e.preventDefault();
@@ -1050,6 +1154,94 @@ function CategorySection({ category, agents, allAgents, allCategories, projects,
         onClose: () => setAgentContextMenu(null)
       });
     })()
+  );
+}
+function ResizeDivider({ onResize, onToggleCollapse, collapsed }) {
+  const [hovered, setHovered] = useState(false);
+  const draggingRef = useRef(false);
+  const startXRef = useRef(0);
+  const handleMouseDown = useCallback((e) => {
+    e.preventDefault();
+    draggingRef.current = true;
+    startXRef.current = e.clientX;
+    document.body.style.userSelect = "none";
+    document.body.style.cursor = "col-resize";
+    const handleMouseMove = (ev) => {
+      const delta = ev.clientX - startXRef.current;
+      if (delta !== 0) {
+        onResize(delta);
+        startXRef.current = ev.clientX;
+      }
+    };
+    const handleMouseUp = () => {
+      draggingRef.current = false;
+      document.body.style.userSelect = "";
+      document.body.style.cursor = "";
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+    };
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+  }, [onResize]);
+  const handleDoubleClick = useCallback(() => {
+    onToggleCollapse();
+  }, [onToggleCollapse]);
+  const chevron = collapsed ? "\u25B6" : "\u25C0";
+  return React2.createElement(
+    "div",
+    {
+      style: {
+        width: 5,
+        cursor: "col-resize",
+        position: "relative",
+        flexShrink: 0
+      },
+      onMouseDown: handleMouseDown,
+      onDoubleClick: handleDoubleClick,
+      onMouseEnter: () => setHovered(true),
+      onMouseLeave: () => setHovered(false),
+      "data-testid": "lounge-sidebar-edge"
+    },
+    // Visible center line
+    React2.createElement("div", {
+      style: {
+        position: "absolute",
+        top: 0,
+        bottom: 0,
+        left: "50%",
+        transform: "translateX(-50%)",
+        width: 1,
+        backgroundColor: hovered ? "rgba(137, 180, 250, 0.6)" : "rgba(88, 91, 112, 0.5)",
+        transition: "background-color 100ms"
+      }
+    }),
+    // Chevron button — only visible on hover
+    hovered && React2.createElement("button", {
+      onClick: (e) => {
+        e.stopPropagation();
+        onToggleCollapse();
+      },
+      style: {
+        position: "absolute",
+        top: "50%",
+        left: "50%",
+        transform: "translate(-50%, -50%)",
+        width: 16,
+        height: 16,
+        borderRadius: "50%",
+        backgroundColor: "#1e1e2e",
+        border: "1px solid rgba(88, 91, 112, 0.5)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontSize: "8px",
+        color: "#a6adc8",
+        cursor: "pointer",
+        padding: 0,
+        zIndex: 10
+      },
+      "data-testid": "lounge-collapse-sidebar"
+    }, chevron)
   );
 }
 function EmptyState() {
@@ -1124,6 +1316,12 @@ function MainPanel({ api }) {
   const placeAgent = useLoungeStore((s) => s.placeAgent);
   const agentOrder = useLoungeStore((s) => s.agentOrder);
   const loadPersistedState = useLoungeStore((s) => s.loadPersistedState);
+  const showTags = useLoungeStore((s) => s.showTags);
+  const toggleShowTags = useLoungeStore((s) => s.toggleShowTags);
+  const sidebarCollapsed = useLoungeStore((s) => s.sidebarCollapsed);
+  const toggleSidebar = useLoungeStore((s) => s.toggleSidebar);
+  const sidebarWidth = useLoungeStore((s) => s.sidebarWidth);
+  const setSidebarWidth = useLoungeStore((s) => s.setSidebarWidth);
   const [loaded, setLoaded] = useState(false);
   useEffect(() => {
     api.storage.global.read(STORAGE_KEY).then((data) => {
@@ -1157,7 +1355,7 @@ function MainPanel({ api }) {
         });
       }
     };
-  }, [api, loaded, renamedLabels, agentCategoryOverrides, customCircles, nextCircleId, categoryOrder, categoryEmojis, agentOrder, collapsed]);
+  }, [api, loaded, renamedLabels, agentCategoryOverrides, customCircles, nextCircleId, categoryOrder, categoryEmojis, agentOrder, collapsed, showTags, sidebarCollapsed, sidebarWidth]);
   const [agentTick, setAgentTick] = useState(0);
   useEffect(() => {
     const sub = api.agents.onAnyChange(() => setAgentTick((n) => n + 1));
@@ -1169,6 +1367,7 @@ function MainPanel({ api }) {
     deriveCategories(projects);
   }, [projects, deriveCategories, loaded]);
   const agents = useMemo(() => api.agents.list(), [api, agentTick]);
+  const orchestrators = useMemo(() => api.agents.listOrchestrators(), [api]);
   const grouped = useMemo(
     () => groupAgentsByCategory(agents, categories, agentCategoryOverrides),
     [agents, categories, agentCategoryOverrides]
@@ -1242,21 +1441,55 @@ function MainPanel({ api }) {
       className: "flex h-full w-full bg-ctp-base",
       "data-testid": "lounge-main-panel"
     },
-    // Left sidebar — agent list
+    // Left sidebar — agent list (collapsible)
     React2.createElement(
       "div",
       {
-        className: "w-64 flex-shrink-0 flex flex-col bg-ctp-mantle border-r border-surface-0 h-full min-h-0"
+        style: {
+          width: sidebarCollapsed ? "0px" : `${sidebarWidth}px`,
+          minWidth: 0,
+          transition: "width 200ms ease-in-out",
+          overflow: "hidden",
+          flexShrink: 0
+        },
+        className: "flex flex-col bg-ctp-mantle h-full min-h-0",
+        "data-testid": "lounge-sidebar"
       },
       // Header
       React2.createElement(
         "div",
         {
-          className: "px-3 py-3 border-b border-surface-0"
+          className: "px-3 py-3 border-b border-surface-0 flex items-center gap-2"
         },
         React2.createElement("h2", {
-          className: "text-xs font-semibold text-ctp-subtext0 uppercase tracking-wider"
-        }, "Lounge")
+          className: "text-xs font-semibold text-ctp-subtext0 uppercase tracking-wider flex-1"
+        }, "Lounge"),
+        // Tags toggle button
+        React2.createElement(
+          "button",
+          {
+            onClick: toggleShowTags,
+            title: showTags ? "Hide tags" : "Show tags",
+            className: "w-5 h-5 flex items-center justify-center rounded text-ctp-overlay0 hover:text-ctp-text hover:bg-surface-0 cursor-pointer transition-colors",
+            "data-testid": "lounge-toggle-tags"
+          },
+          React2.createElement(
+            "svg",
+            {
+              width: 12,
+              height: 12,
+              viewBox: "0 0 24 24",
+              fill: "none",
+              stroke: "currentColor",
+              strokeWidth: 2,
+              strokeLinecap: "round",
+              strokeLinejoin: "round",
+              style: { opacity: showTags ? 1 : 0.4 }
+            },
+            React2.createElement("path", { d: "M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z" }),
+            React2.createElement("line", { x1: "7", y1: "7", x2: "7.01", y2: "7" })
+          )
+        )
       ),
       // Scrollable category list
       React2.createElement(
@@ -1276,6 +1509,8 @@ function MainPanel({ api }) {
             projects,
             isCollapsed: collapsed.has(cat.id),
             selectedAgentId,
+            showTags,
+            orchestrators,
             api,
             onToggle: () => toggleCollapsed(cat.id),
             onSelectAgent: handleSelectAgent,
@@ -1289,6 +1524,15 @@ function MainPanel({ api }) {
         }) : React2.createElement(EmptyState)
       )
     ),
+    // Sidebar resize divider (matches host ResizeDivider pattern)
+    React2.createElement(ResizeDivider, {
+      collapsed: sidebarCollapsed,
+      onToggleCollapse: toggleSidebar,
+      onResize: (delta) => {
+        const current = useLoungeStore.getState().sidebarWidth;
+        setSidebarWidth(current + delta);
+      }
+    }),
     // Right content — selected agent view
     React2.createElement(
       "div",

--- a/plugins/lounge/dist/main.js
+++ b/plugins/lounge/dist/main.js
@@ -437,20 +437,6 @@ function activate(ctx, _api) {
 }
 function deactivate() {
 }
-function statusColor(status) {
-  switch (status) {
-    case "running":
-      return "bg-ctp-green";
-    case "sleeping":
-      return "bg-ctp-yellow";
-    case "error":
-      return "bg-ctp-red";
-    case "creating":
-      return "bg-ctp-blue";
-    default:
-      return "bg-ctp-overlay0";
-  }
-}
 function statusLabel(status) {
   switch (status) {
     case "running":
@@ -465,11 +451,15 @@ function statusLabel(status) {
       return status;
   }
 }
-function AgentRow({ agent, displayName, isSelected, showTags, orchestrators, onClick, onContextMenu }) {
+function AgentRow({ agent, displayName, isSelected, showTags, orchestrators, api, onClick, onContextMenu }) {
   const handleDragStart = useCallback((e) => {
     e.dataTransfer.setData("application/x-lounge-agent", agent.id);
     e.dataTransfer.effectAllowed = "move";
   }, [agent.id]);
+  const { AgentAvatar } = api.widgets;
+  const detailed = api.agents.getDetailedStatus(agent.id);
+  const statusText = detailed?.message ?? statusLabel(agent.status);
+  const statusTextColor = detailed?.state === "needs_permission" ? "text-ctp-peach" : detailed?.state === "tool_error" ? "text-ctp-red" : "text-ctp-overlay0";
   return React2.createElement(
     "button",
     {
@@ -482,9 +472,11 @@ function AgentRow({ agent, displayName, isSelected, showTags, orchestrators, onC
       "data-testid": `lounge-agent-${agent.id}`,
       className: `w-full text-left px-3 py-2 text-sm cursor-pointer transition-colors flex items-center gap-3 ${isSelected ? "bg-surface-1 text-ctp-text" : "text-ctp-subtext1 hover:bg-surface-0 hover:text-ctp-text"}`
     },
-    React2.createElement("span", {
-      className: `w-2 h-2 rounded-full flex-shrink-0 ${statusColor(agent.status)}`
-    }),
+    React2.createElement(
+      "div",
+      { className: "flex-shrink-0" },
+      React2.createElement(AgentAvatar, { agentId: agent.id, size: "sm", showStatusRing: true })
+    ),
     React2.createElement(
       "div",
       { className: "min-w-0 flex-1" },
@@ -517,11 +509,12 @@ function AgentRow({ agent, displayName, isSelected, showTags, orchestrators, onC
           style: { backgroundColor: FREE_AGENT_COLOR.bg, color: FREE_AGENT_COLOR.text, fontSize: "10px", padding: "1px 6px", borderRadius: "4px", lineHeight: "16px", whiteSpace: "nowrap" },
           "data-testid": "lounge-tag-free"
         }, "Free")
-      )
-    ),
-    agent.status === "running" && React2.createElement("span", {
-      className: "text-[10px] text-ctp-green flex-shrink-0"
-    }, "\u25CF")
+      ),
+      React2.createElement("span", {
+        className: `text-[10px] ${statusTextColor} block mt-0.5`,
+        "data-testid": `lounge-agent-status-${agent.id}`
+      }, statusText)
+    )
   );
 }
 function CategoryContextMenu({ position, categoryId, onRename, onDelete, onClose }) {
@@ -1127,6 +1120,7 @@ function CategorySection({ category, agents, allAgents, allCategories, projects,
           isSelected: selectedAgentId === agent.id,
           showTags,
           orchestrators,
+          api,
           onClick: () => onSelectAgent(agent.id, agent.projectId),
           onContextMenu: (e) => {
             e.preventDefault();

--- a/plugins/lounge/dist/main.js
+++ b/plugins/lounge/dist/main.js
@@ -1,0 +1,1124 @@
+// src/main.ts
+import React2, { useEffect, useMemo, useState, useCallback, useRef } from "react";
+
+// node_modules/zustand/esm/vanilla.mjs
+var createStoreImpl = (createState) => {
+  let state;
+  const listeners = /* @__PURE__ */ new Set();
+  const setState = (partial, replace) => {
+    const nextState = typeof partial === "function" ? partial(state) : partial;
+    if (!Object.is(nextState, state)) {
+      const previousState = state;
+      state = (replace != null ? replace : typeof nextState !== "object" || nextState === null) ? nextState : Object.assign({}, state, nextState);
+      listeners.forEach((listener) => listener(state, previousState));
+    }
+  };
+  const getState = () => state;
+  const getInitialState = () => initialState;
+  const subscribe = (listener) => {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  };
+  const api = { setState, getState, getInitialState, subscribe };
+  const initialState = state = createState(setState, getState, api);
+  return api;
+};
+var createStore = (createState) => createState ? createStoreImpl(createState) : createStoreImpl;
+
+// node_modules/zustand/esm/react.mjs
+import React from "react";
+var identity = (arg) => arg;
+function useStore(api, selector = identity) {
+  const slice = React.useSyncExternalStore(
+    api.subscribe,
+    React.useCallback(() => selector(api.getState()), [api, selector]),
+    React.useCallback(() => selector(api.getInitialState()), [api, selector])
+  );
+  React.useDebugValue(slice);
+  return slice;
+}
+var createImpl = (createState) => {
+  const api = createStore(createState);
+  const useBoundStore = (selector) => useStore(api, selector);
+  Object.assign(useBoundStore, api);
+  return useBoundStore;
+};
+var create = (createState) => createState ? createImpl(createState) : createImpl;
+
+// src/state.ts
+var DEFAULT_CIRCLE_ID = "circle:general";
+var DEFAULT_CIRCLE_LABEL = "General";
+var DEFAULT_CIRCLE_EMOJI = "\u{1F4AC}";
+var DEFAULT_PROJECT_EMOJI = "\u{1F4C1}";
+var DEFAULT_CUSTOM_EMOJI = "\u2B50";
+var RESERVED_NAMES = /* @__PURE__ */ new Set(["general"]);
+function isReservedCircleName(label) {
+  return RESERVED_NAMES.has(label.toLowerCase().trim());
+}
+function isDefaultCircle(categoryId) {
+  return categoryId === DEFAULT_CIRCLE_ID;
+}
+function isDuplicateCircleName(label, categories, excludeId) {
+  const normalized = label.toLowerCase().trim();
+  return categories.some((c) => c.id !== excludeId && c.label.toLowerCase().trim() === normalized);
+}
+function getPersistedState(state) {
+  return {
+    renamedLabels: state.renamedLabels,
+    agentCategoryOverrides: state.agentCategoryOverrides,
+    customCircles: state.customCircles,
+    nextCircleId: state.nextCircleId,
+    categoryOrder: state.categoryOrder,
+    categoryEmojis: state.categoryEmojis,
+    collapsed: Array.from(state.collapsed)
+  };
+}
+function groupAgentsByCategory(agents, categories, overrides = {}) {
+  const projectToCategory = /* @__PURE__ */ new Map();
+  for (const cat of categories) {
+    if (cat.projectId) {
+      projectToCategory.set(cat.projectId, cat.id);
+    }
+  }
+  const validCategoryIds = new Set(categories.map((c) => c.id));
+  const groups = /* @__PURE__ */ new Map();
+  for (const cat of categories) {
+    groups.set(cat.id, []);
+  }
+  for (const agent of agents) {
+    const overrideCatId = overrides[agent.id];
+    const catId = overrideCatId && validCategoryIds.has(overrideCatId) ? overrideCatId : projectToCategory.get(agent.projectId);
+    if (catId && groups.has(catId)) {
+      groups.get(catId).push(agent);
+    } else if (groups.has(DEFAULT_CIRCLE_ID)) {
+      groups.get(DEFAULT_CIRCLE_ID).push(agent);
+    }
+  }
+  return groups;
+}
+function disambiguateAgentName(agent, allAgents, projects) {
+  const sameNameAgents = allAgents.filter((a) => a.name === agent.name);
+  if (sameNameAgents.length <= 1) return agent.name;
+  const project = projects.find((p) => p.id === agent.projectId);
+  const projectLabel = project?.name ?? agent.projectId;
+  return `${projectLabel}/${agent.name}`;
+}
+var GENERAL_CIRCLE = { id: DEFAULT_CIRCLE_ID, label: DEFAULT_CIRCLE_LABEL, emoji: DEFAULT_CIRCLE_EMOJI };
+function applyCategoryOrder(categories, order) {
+  if (order.length === 0) return categories;
+  const byId = new Map(categories.map((c) => [c.id, c]));
+  const result = [];
+  const placed = /* @__PURE__ */ new Set();
+  for (const id of order) {
+    if (id === DEFAULT_CIRCLE_ID) continue;
+    const cat = byId.get(id);
+    if (cat) {
+      result.push(cat);
+      placed.add(id);
+    }
+  }
+  for (const cat of categories) {
+    if (!placed.has(cat.id) && cat.id !== DEFAULT_CIRCLE_ID) {
+      result.push(cat);
+    }
+  }
+  const general = byId.get(DEFAULT_CIRCLE_ID);
+  if (general) result.push(general);
+  return result;
+}
+var createLoungeStore = () => create((set, get) => ({
+  categories: [GENERAL_CIRCLE],
+  collapsed: /* @__PURE__ */ new Set(),
+  selectedAgentId: null,
+  selectedProjectId: null,
+  renamedLabels: {},
+  agentCategoryOverrides: {},
+  customCircles: [],
+  nextCircleId: 1,
+  categoryOrder: [],
+  categoryEmojis: {},
+  hydrated: false,
+  deriveCategories(projects) {
+    set((state) => {
+      const projectCategories = projects.map((p) => {
+        const catId = `project:${p.id}`;
+        const rawLabel = state.renamedLabels[catId] ?? p.name;
+        const label = isReservedCircleName(rawLabel) ? `${rawLabel} (project)` : rawLabel;
+        return {
+          id: catId,
+          label,
+          emoji: state.categoryEmojis[catId] ?? DEFAULT_PROJECT_EMOJI,
+          projectId: p.id
+        };
+      });
+      const customWithEmojis = state.customCircles.map((c) => ({
+        ...c,
+        emoji: state.categoryEmojis[c.id] ?? c.emoji
+      }));
+      const general = {
+        ...GENERAL_CIRCLE,
+        emoji: state.categoryEmojis[DEFAULT_CIRCLE_ID] ?? GENERAL_CIRCLE.emoji
+      };
+      const unordered = [...projectCategories, ...customWithEmojis, general];
+      const newCategories = applyCategoryOrder(unordered, state.categoryOrder);
+      const newIds = new Set(newCategories.map((c) => c.id));
+      const newCollapsed = /* @__PURE__ */ new Set();
+      for (const id of state.collapsed) {
+        if (newIds.has(id)) newCollapsed.add(id);
+      }
+      return { categories: newCategories, collapsed: newCollapsed };
+    });
+  },
+  toggleCollapsed(categoryId) {
+    set((state) => {
+      const next = new Set(state.collapsed);
+      if (next.has(categoryId)) {
+        next.delete(categoryId);
+      } else {
+        next.add(categoryId);
+      }
+      return { collapsed: next };
+    });
+  },
+  selectAgent(agentId, projectId) {
+    set({ selectedAgentId: agentId, selectedProjectId: projectId ?? null });
+  },
+  renameCategory(categoryId, label) {
+    if (isDefaultCircle(categoryId)) return;
+    if (!label.trim() || isReservedCircleName(label)) return;
+    if (!get().hydrated) return;
+    if (isDuplicateCircleName(label, get().categories, categoryId)) return;
+    set((state) => {
+      const newLabels = { ...state.renamedLabels, [categoryId]: label };
+      const newCategories = state.categories.map(
+        (c) => c.id === categoryId ? { ...c, label } : c
+      );
+      const newCustomCircles = state.customCircles.map(
+        (c) => c.id === categoryId ? { ...c, label } : c
+      );
+      return { renamedLabels: newLabels, categories: newCategories, customCircles: newCustomCircles };
+    });
+  },
+  moveAgent(agentId, targetCategoryId) {
+    if (!get().hydrated) return;
+    set((state) => ({
+      agentCategoryOverrides: { ...state.agentCategoryOverrides, [agentId]: targetCategoryId }
+    }));
+  },
+  addCircle(label) {
+    if (!label.trim()) return "";
+    if (isReservedCircleName(label)) return "";
+    if (!get().hydrated) return "";
+    if (isDuplicateCircleName(label, get().categories)) return "";
+    let newId = "";
+    set((state) => {
+      const id = `circle:${state.nextCircleId}`;
+      newId = id;
+      const circle = { id, label, emoji: DEFAULT_CUSTOM_EMOJI };
+      const newCustomCircles = [...state.customCircles, circle];
+      const cats = state.categories.filter((c) => c.id !== DEFAULT_CIRCLE_ID);
+      return {
+        customCircles: newCustomCircles,
+        categories: [...cats, circle, GENERAL_CIRCLE],
+        nextCircleId: state.nextCircleId + 1
+      };
+    });
+    return newId;
+  },
+  deleteCircle(circleId) {
+    if (isDefaultCircle(circleId)) return;
+    if (!circleId.startsWith("circle:")) return;
+    if (!get().hydrated) return;
+    set((state) => {
+      const newCustomCircles = state.customCircles.filter((c) => c.id !== circleId);
+      const newCategories = state.categories.filter((c) => c.id !== circleId);
+      const newOverrides = { ...state.agentCategoryOverrides };
+      for (const [agentId, catId] of Object.entries(newOverrides)) {
+        if (catId === circleId) delete newOverrides[agentId];
+      }
+      const newOrder = state.categoryOrder.filter((id) => id !== circleId);
+      const { [circleId]: _emoji, ...newEmojis } = state.categoryEmojis;
+      const { [circleId]: _label, ...newLabels } = state.renamedLabels;
+      const newCollapsed = new Set(state.collapsed);
+      newCollapsed.delete(circleId);
+      return {
+        customCircles: newCustomCircles,
+        categories: newCategories,
+        agentCategoryOverrides: newOverrides,
+        categoryOrder: newOrder,
+        categoryEmojis: newEmojis,
+        renamedLabels: newLabels,
+        collapsed: newCollapsed
+      };
+    });
+  },
+  reorderCategory(fromId, toId) {
+    if (isDefaultCircle(fromId) || isDefaultCircle(toId)) return;
+    if (fromId === toId) return;
+    if (!get().hydrated) return;
+    set((state) => {
+      const cats = state.categories.filter((c) => c.id !== DEFAULT_CIRCLE_ID);
+      const fromIdx = cats.findIndex((c) => c.id === fromId);
+      const toIdx = cats.findIndex((c) => c.id === toId);
+      if (fromIdx === -1 || toIdx === -1) return state;
+      const reordered = [...cats];
+      const [moved] = reordered.splice(fromIdx, 1);
+      reordered.splice(toIdx, 0, moved);
+      reordered.push(GENERAL_CIRCLE);
+      return {
+        categories: reordered,
+        categoryOrder: reordered.map((c) => c.id)
+      };
+    });
+  },
+  setCategoryEmoji(categoryId, emoji) {
+    if (!get().hydrated) return;
+    set((state) => {
+      const newEmojis = { ...state.categoryEmojis, [categoryId]: emoji };
+      const newCategories = state.categories.map(
+        (c) => c.id === categoryId ? { ...c, emoji } : c
+      );
+      const newCustomCircles = state.customCircles.map(
+        (c) => c.id === categoryId ? { ...c, emoji } : c
+      );
+      return { categoryEmojis: newEmojis, categories: newCategories, customCircles: newCustomCircles };
+    });
+  },
+  loadPersistedState(data) {
+    set({
+      renamedLabels: data.renamedLabels ?? {},
+      agentCategoryOverrides: data.agentCategoryOverrides ?? {},
+      customCircles: data.customCircles ?? [],
+      nextCircleId: data.nextCircleId ?? 1,
+      categoryOrder: data.categoryOrder ?? [],
+      categoryEmojis: data.categoryEmojis ?? {},
+      collapsed: new Set(data.collapsed ?? []),
+      hydrated: true
+    });
+  }
+}));
+
+// src/main.ts
+var useLoungeStore = createLoungeStore();
+var STORAGE_KEY = "lounge-state";
+function activate(ctx, _api) {
+}
+function deactivate() {
+}
+function statusColor(status) {
+  switch (status) {
+    case "running":
+      return "bg-ctp-green";
+    case "sleeping":
+      return "bg-ctp-yellow";
+    case "error":
+      return "bg-ctp-red";
+    case "creating":
+      return "bg-ctp-blue";
+    default:
+      return "bg-ctp-overlay0";
+  }
+}
+function statusLabel(status) {
+  switch (status) {
+    case "running":
+      return "Running";
+    case "sleeping":
+      return "Sleeping";
+    case "error":
+      return "Error";
+    case "creating":
+      return "Creating";
+    default:
+      return status;
+  }
+}
+function AgentRow({ agent, displayName, isSelected, onClick, onContextMenu }) {
+  const handleDragStart = useCallback((e) => {
+    e.dataTransfer.setData("application/x-lounge-agent", agent.id);
+    e.dataTransfer.effectAllowed = "move";
+  }, [agent.id]);
+  return React2.createElement(
+    "button",
+    {
+      key: agent.id,
+      onClick,
+      onContextMenu,
+      draggable: true,
+      onDragStart: handleDragStart,
+      title: `${displayName} \u2014 ${statusLabel(agent.status)}`,
+      "data-testid": `lounge-agent-${agent.id}`,
+      className: `w-full text-left px-3 py-2 text-sm cursor-pointer transition-colors flex items-center gap-3 ${isSelected ? "bg-surface-1 text-ctp-text" : "text-ctp-subtext1 hover:bg-surface-0 hover:text-ctp-text"}`
+    },
+    React2.createElement("span", {
+      className: `w-2 h-2 rounded-full flex-shrink-0 ${statusColor(agent.status)}`
+    }),
+    React2.createElement("span", { className: "truncate flex-1" }, displayName),
+    agent.status === "running" && React2.createElement("span", {
+      className: "text-[10px] text-ctp-green flex-shrink-0"
+    }, "\u25CF")
+  );
+}
+function CategoryContextMenu({ position, categoryId, onRename, onDelete, onClose }) {
+  const menuRef = useRef(null);
+  const isCustomCircle = categoryId.startsWith("circle:") && !isDefaultCircle(categoryId);
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (menuRef.current && !menuRef.current.contains(e.target)) onClose();
+    };
+    const handleEscape = (e) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleEscape);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [onClose]);
+  const style = useMemo(() => {
+    const menuWidth = 160;
+    const menuHeight = (isCustomCircle ? 64 : 32) + 8;
+    const x = Math.min(position.x, window.innerWidth - menuWidth - 8);
+    const y = Math.min(position.y, window.innerHeight - menuHeight - 8);
+    return { left: x, top: y };
+  }, [position, isCustomCircle]);
+  return React2.createElement(
+    "div",
+    {
+      ref: menuRef,
+      className: "fixed z-50 min-w-[160px] py-1 rounded-lg shadow-xl border border-surface-1 bg-ctp-mantle",
+      style,
+      "data-testid": "lounge-category-context-menu"
+    },
+    React2.createElement(
+      "button",
+      {
+        className: "w-full flex items-center gap-2 px-3 py-1.5 text-xs text-ctp-subtext0 hover:bg-surface-1 hover:text-ctp-text transition-colors cursor-pointer",
+        onClick: (e) => {
+          e.stopPropagation();
+          onRename();
+          onClose();
+        },
+        "data-testid": "lounge-ctx-rename"
+      },
+      React2.createElement(
+        "svg",
+        {
+          width: 12,
+          height: 12,
+          viewBox: "0 0 24 24",
+          fill: "none",
+          stroke: "currentColor",
+          strokeWidth: 2,
+          strokeLinecap: "round",
+          strokeLinejoin: "round"
+        },
+        React2.createElement("path", { d: "M17 3a2.83 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z" })
+      ),
+      React2.createElement("span", null, "Rename")
+    ),
+    // Delete option — only for custom circles (not project-derived)
+    isCustomCircle && React2.createElement(
+      "button",
+      {
+        className: "w-full flex items-center gap-2 px-3 py-1.5 text-xs text-ctp-red hover:bg-surface-1 transition-colors cursor-pointer",
+        onClick: (e) => {
+          e.stopPropagation();
+          onDelete();
+          onClose();
+        },
+        "data-testid": "lounge-ctx-delete"
+      },
+      React2.createElement(
+        "svg",
+        {
+          width: 12,
+          height: 12,
+          viewBox: "0 0 24 24",
+          fill: "none",
+          stroke: "currentColor",
+          strokeWidth: 2,
+          strokeLinecap: "round",
+          strokeLinejoin: "round"
+        },
+        React2.createElement("polyline", { points: "3 6 5 6 21 6" }),
+        React2.createElement("path", { d: "M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" })
+      ),
+      React2.createElement("span", null, "Delete")
+    )
+  );
+}
+function AgentContextMenu({ position, categories, currentCategoryId, onMoveTo, onCreateCircle, onClose }) {
+  const menuRef = useRef(null);
+  const [showSubmenu, setShowSubmenu] = useState(false);
+  const moveToRef = useRef(null);
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (menuRef.current && !menuRef.current.contains(e.target)) onClose();
+    };
+    const handleEscape = (e) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleEscape);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleEscape);
+    };
+  }, [onClose]);
+  const style = useMemo(() => {
+    const menuWidth = 160;
+    const menuHeight = 32 + 8;
+    const x = Math.min(position.x, window.innerWidth - menuWidth - 8);
+    const y = Math.min(position.y, window.innerHeight - menuHeight - 8);
+    return { left: x, top: y };
+  }, [position]);
+  const submenuStyle = useMemo(() => {
+    if (!moveToRef.current) return { left: "100%", top: 0 };
+    const rect = moveToRef.current.getBoundingClientRect();
+    const submenuWidth = 180;
+    const submenuHeight = categories.length * 28 + 8;
+    const goLeft = rect.right + submenuWidth > window.innerWidth - 8;
+    const x = goLeft ? -submenuWidth : rect.width;
+    const y = Math.min(0, window.innerHeight - rect.top - submenuHeight - 8);
+    return { left: x, top: y };
+  }, [showSubmenu, categories.length]);
+  return React2.createElement(
+    "div",
+    {
+      ref: menuRef,
+      className: "fixed z-50 min-w-[160px] py-1 rounded-lg shadow-xl border border-surface-1 bg-ctp-mantle",
+      style,
+      "data-testid": "lounge-agent-context-menu"
+    },
+    // "Move to" with submenu
+    React2.createElement(
+      "div",
+      { className: "relative" },
+      React2.createElement(
+        "button",
+        {
+          ref: moveToRef,
+          className: "w-full flex items-center gap-2 px-3 py-1.5 text-xs text-ctp-subtext0 hover:bg-surface-1 hover:text-ctp-text transition-colors cursor-pointer",
+          onMouseEnter: () => setShowSubmenu(true),
+          onMouseLeave: () => setShowSubmenu(false),
+          onClick: () => setShowSubmenu((v) => !v),
+          "data-testid": "lounge-ctx-move-to"
+        },
+        // Move icon
+        React2.createElement(
+          "svg",
+          {
+            width: 12,
+            height: 12,
+            viewBox: "0 0 24 24",
+            fill: "none",
+            stroke: "currentColor",
+            strokeWidth: 2,
+            strokeLinecap: "round",
+            strokeLinejoin: "round"
+          },
+          React2.createElement("path", { d: "M15 3h6v6" }),
+          React2.createElement("path", { d: "M10 14L21 3" }),
+          React2.createElement("path", { d: "M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" })
+        ),
+        React2.createElement("span", { className: "flex-1 text-left" }, "Move to"),
+        // Chevron right
+        React2.createElement(
+          "svg",
+          {
+            width: 10,
+            height: 10,
+            viewBox: "0 0 24 24",
+            fill: "none",
+            stroke: "currentColor",
+            strokeWidth: 2,
+            strokeLinecap: "round",
+            strokeLinejoin: "round"
+          },
+          React2.createElement("polyline", { points: "9 18 15 12 9 6" })
+        )
+      ),
+      // Submenu
+      showSubmenu && React2.createElement(
+        "div",
+        {
+          className: "absolute z-50 min-w-[180px] py-1 rounded-lg shadow-xl border border-surface-1 bg-ctp-mantle",
+          style: submenuStyle,
+          onMouseEnter: () => setShowSubmenu(true),
+          onMouseLeave: () => setShowSubmenu(false),
+          "data-testid": "lounge-move-to-submenu"
+        },
+        categories.map(
+          (cat) => React2.createElement(
+            "button",
+            {
+              key: cat.id,
+              className: `w-full text-left px-3 py-1.5 text-xs transition-colors cursor-pointer ${cat.id === currentCategoryId ? "text-ctp-overlay0 cursor-default" : "text-ctp-subtext0 hover:bg-surface-1 hover:text-ctp-text"}`,
+              disabled: cat.id === currentCategoryId,
+              onClick: (e) => {
+                e.stopPropagation();
+                if (cat.id !== currentCategoryId) {
+                  onMoveTo(cat.id);
+                  onClose();
+                }
+              },
+              "data-testid": `lounge-move-to-${cat.id}`
+            },
+            React2.createElement("span", null, cat.label),
+            cat.id === currentCategoryId && React2.createElement("span", {
+              className: "ml-2 text-[10px] text-ctp-overlay0"
+            }, "(current)")
+          )
+        ),
+        // Divider + Create new
+        React2.createElement("div", { className: "mx-2 my-1 border-t border-surface-1" }),
+        React2.createElement(
+          "button",
+          {
+            className: "w-full flex items-center gap-2 px-3 py-1.5 text-xs text-ctp-accent hover:bg-surface-1 transition-colors cursor-pointer",
+            onClick: (e) => {
+              e.stopPropagation();
+              onCreateCircle();
+              onClose();
+            },
+            "data-testid": "lounge-move-to-create-new"
+          },
+          React2.createElement(
+            "svg",
+            {
+              width: 12,
+              height: 12,
+              viewBox: "0 0 24 24",
+              fill: "none",
+              stroke: "currentColor",
+              strokeWidth: 2,
+              strokeLinecap: "round",
+              strokeLinejoin: "round"
+            },
+            React2.createElement("line", { x1: "12", y1: "5", x2: "12", y2: "19" }),
+            React2.createElement("line", { x1: "5", y1: "12", x2: "19", y2: "12" })
+          ),
+          React2.createElement("span", null, "Create new")
+        )
+      )
+    )
+  );
+}
+var CHEVRON_RIGHT = React2.createElement("svg", {
+  width: 12,
+  height: 12,
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 2,
+  strokeLinecap: "round",
+  strokeLinejoin: "round"
+}, React2.createElement("polyline", { points: "9 18 15 12 9 6" }));
+var CHEVRON_DOWN = React2.createElement("svg", {
+  width: 12,
+  height: 12,
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 2,
+  strokeLinecap: "round",
+  strokeLinejoin: "round"
+}, React2.createElement("polyline", { points: "6 9 12 15 18 9" }));
+var EMOJI_OPTIONS = [
+  "\u2B50",
+  "\u{1F4AC}",
+  "\u{1F525}",
+  "\u{1F680}",
+  "\u{1F4A1}",
+  "\u{1F3AF}",
+  "\u{1F3E0}",
+  "\u{1F4C1}",
+  "\u{1F6E0}\uFE0F",
+  "\u{1F9EA}",
+  "\u{1F4CB}",
+  "\u{1F3A8}",
+  "\u{1F512}",
+  "\u{1F310}",
+  "\u{1F4CA}",
+  "\u{1F916}",
+  "\u{1F48E}",
+  "\u{1F3B5}",
+  "\u{1F4F8}",
+  "\u{1F3C6}",
+  "\u2764\uFE0F",
+  "\u26A1",
+  "\u{1F31F}",
+  "\u{1F3AE}"
+];
+function CircleDialog({ mode, onConfirm, onCancel, existingCategories, initialName, initialEmoji, editCategoryId }) {
+  const [value, setValue] = useState(initialName ?? "");
+  const [emoji, setEmoji] = useState(initialEmoji ?? DEFAULT_CUSTOM_EMOJI);
+  const [showEmojis, setShowEmojis] = useState(false);
+  const inputRef = useRef(null);
+  useEffect(() => {
+    inputRef.current?.focus();
+    if (mode === "edit") inputRef.current?.select();
+  }, [mode]);
+  useEffect(() => {
+    const handleEscape = (e) => {
+      if (e.key === "Escape") onCancel();
+    };
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [onCancel]);
+  const handleSubmit = useCallback(() => {
+    const trimmed2 = value.trim();
+    if (trimmed2 && !isReservedCircleName(trimmed2) && !isDuplicateCircleName(trimmed2, existingCategories, editCategoryId)) {
+      onConfirm(trimmed2, emoji);
+    }
+  }, [value, emoji, onConfirm, existingCategories, editCategoryId]);
+  const trimmed = value.trim();
+  const isReserved = trimmed.length > 0 && isReservedCircleName(trimmed);
+  const isDuplicate = trimmed.length > 0 && !isReserved && isDuplicateCircleName(trimmed, existingCategories, editCategoryId);
+  const isValid = trimmed.length > 0 && !isReserved && !isDuplicate;
+  const isCreate = mode === "create";
+  return React2.createElement(
+    "div",
+    {
+      className: "fixed inset-0 z-50 flex items-center justify-center bg-black/50",
+      onClick: onCancel
+    },
+    React2.createElement(
+      "div",
+      {
+        className: "bg-ctp-mantle border border-surface-1 rounded-xl p-4 w-72 shadow-2xl",
+        onClick: (e) => e.stopPropagation()
+      },
+      React2.createElement("h3", {
+        className: "text-sm font-semibold text-ctp-text mb-3"
+      }, isCreate ? "Create a new circle" : "Rename circle"),
+      // Emoji + input row
+      React2.createElement(
+        "div",
+        { className: "flex items-center gap-2" },
+        // Emoji button
+        React2.createElement("button", {
+          onClick: () => setShowEmojis(!showEmojis),
+          className: "w-8 h-8 flex-shrink-0 flex items-center justify-center rounded-lg bg-ctp-base border border-surface-1 text-base hover:bg-surface-0 transition-colors cursor-pointer",
+          title: "Choose icon",
+          "data-testid": "lounge-circle-dialog-emoji-btn"
+        }, emoji),
+        React2.createElement("input", {
+          ref: inputRef,
+          type: "text",
+          value,
+          placeholder: "Enter circle name",
+          className: "flex-1 min-w-0 px-3 py-1.5 rounded-lg bg-ctp-base border border-surface-1 text-xs text-ctp-text placeholder-ctp-overlay0 outline-none focus:ring-1 focus:ring-ctp-accent",
+          onChange: (e) => setValue(e.target.value),
+          onKeyDown: (e) => {
+            if (e.key === "Enter" && isValid) handleSubmit();
+            if (e.key === "Escape") onCancel();
+          },
+          "data-testid": "lounge-circle-dialog-input"
+        })
+      ),
+      // Inline emoji picker
+      showEmojis && React2.createElement(
+        "div",
+        {
+          className: "mt-2 p-2 rounded-lg bg-ctp-base border border-surface-1 grid grid-cols-8 gap-1",
+          "data-testid": "lounge-circle-dialog-emoji-picker"
+        },
+        ...EMOJI_OPTIONS.map(
+          (e) => React2.createElement("button", {
+            key: e,
+            onClick: () => {
+              setEmoji(e);
+              setShowEmojis(false);
+            },
+            className: `w-7 h-7 flex items-center justify-center rounded text-sm cursor-pointer transition-colors ${e === emoji ? "bg-surface-1 ring-1 ring-ctp-accent" : "hover:bg-surface-0"}`
+          }, e)
+        )
+      ),
+      isReserved && React2.createElement("p", {
+        className: "text-[10px] text-ctp-red mt-1"
+      }, "This name is reserved"),
+      isDuplicate && React2.createElement("p", {
+        className: "text-[10px] text-ctp-red mt-1"
+      }, "A circle with this name already exists"),
+      React2.createElement(
+        "div",
+        {
+          className: "flex justify-end gap-2 mt-3"
+        },
+        React2.createElement("button", {
+          onClick: onCancel,
+          className: "px-3 py-1 rounded-md text-xs text-ctp-subtext0 hover:text-ctp-text hover:bg-surface-0 transition-colors cursor-pointer",
+          "data-testid": "lounge-circle-dialog-cancel"
+        }, "Cancel"),
+        React2.createElement("button", {
+          onClick: handleSubmit,
+          disabled: !isValid,
+          className: `px-3 py-1 rounded-md text-xs transition-colors cursor-pointer ${isValid ? "bg-ctp-accent text-ctp-base hover:opacity-90" : "bg-surface-1 text-ctp-overlay0 cursor-not-allowed"}`,
+          "data-testid": "lounge-circle-dialog-confirm"
+        }, isCreate ? "Create" : "Save")
+      )
+    )
+  );
+}
+function CategorySection({ category, agents, allAgents, allCategories, projects, isCollapsed, selectedAgentId, onToggle, onSelectAgent, onEditCircle, onDelete, onMoveAgent, onCreateCircle, onReorderCategory }) {
+  const [contextMenu, setContextMenu] = useState(null);
+  const [agentContextMenu, setAgentContextMenu] = useState(null);
+  const [dragOver, setDragOver] = useState(false);
+  const handleContextMenu = useCallback((e) => {
+    if (isDefaultCircle(category.id)) return;
+    e.preventDefault();
+    setContextMenu({ x: e.clientX, y: e.clientY });
+  }, [category.id]);
+  const isGeneralCircle = isDefaultCircle(category.id);
+  const handleDragStart = useCallback((e) => {
+    if (isGeneralCircle) {
+      e.preventDefault();
+      return;
+    }
+    e.dataTransfer.setData("application/x-lounge-category", category.id);
+    e.dataTransfer.effectAllowed = "move";
+  }, [category.id, isGeneralCircle]);
+  const handleDragOver = useCallback((e) => {
+    const hasAgent = e.dataTransfer.types.includes("application/x-lounge-agent");
+    const hasCategory = e.dataTransfer.types.includes("application/x-lounge-category");
+    if (!hasAgent && !hasCategory) return;
+    if (hasCategory && isGeneralCircle) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "move";
+    setDragOver(true);
+  }, [isGeneralCircle]);
+  const handleDragLeave = useCallback(() => {
+    setDragOver(false);
+  }, []);
+  const handleDrop = useCallback((e) => {
+    e.preventDefault();
+    setDragOver(false);
+    const agentId = e.dataTransfer.getData("application/x-lounge-agent");
+    if (agentId) {
+      onMoveAgent(agentId, category.id);
+      return;
+    }
+    const fromCategoryId = e.dataTransfer.getData("application/x-lounge-category");
+    if (fromCategoryId && fromCategoryId !== category.id && !isGeneralCircle) {
+      onReorderCategory(fromCategoryId, category.id);
+    }
+  }, [category.id, onMoveAgent, onReorderCategory, isGeneralCircle]);
+  return React2.createElement(
+    "div",
+    {
+      "data-testid": `lounge-category-${category.id}`,
+      onDragOver: handleDragOver,
+      onDragLeave: handleDragLeave,
+      onDrop: handleDrop
+    },
+    // Category header
+    React2.createElement(
+      "button",
+      {
+        onClick: onToggle,
+        onContextMenu: handleContextMenu,
+        draggable: !isGeneralCircle,
+        onDragStart: handleDragStart,
+        className: `w-full flex items-center gap-2 px-3 py-2 text-xs font-semibold text-ctp-subtext0 uppercase tracking-wider hover:bg-surface-0 cursor-pointer transition-colors ${dragOver ? "bg-surface-1 ring-1 ring-ctp-accent ring-inset" : ""}`,
+        "data-testid": `lounge-category-toggle-${category.id}`
+      },
+      isCollapsed ? CHEVRON_RIGHT : CHEVRON_DOWN,
+      React2.createElement("span", { className: "text-sm flex-shrink-0" }, category.emoji || "\u{1F4C1}"),
+      React2.createElement("span", { className: "flex-1 text-left truncate" }, category.label),
+      React2.createElement("span", { className: "text-[10px] text-ctp-overlay0 tabular-nums" }, String(agents.length))
+    ),
+    // Context menu
+    contextMenu && React2.createElement(CategoryContextMenu, {
+      position: contextMenu,
+      categoryId: category.id,
+      onRename: () => {
+        setContextMenu(null);
+        onEditCircle(category.id);
+      },
+      onDelete: () => onDelete(category.id),
+      onClose: () => setContextMenu(null)
+    }),
+    // Agent rows (hidden when collapsed)
+    !isCollapsed && agents.length > 0 && agents.map((agent) => {
+      const displayName = disambiguateAgentName(agent, allAgents, projects);
+      return React2.createElement(AgentRow, {
+        key: agent.id,
+        agent,
+        displayName,
+        isSelected: selectedAgentId === agent.id,
+        onClick: () => onSelectAgent(agent.id, agent.projectId),
+        onContextMenu: (e) => {
+          e.preventDefault();
+          setAgentContextMenu({ agentId: agent.id, x: e.clientX, y: e.clientY });
+        }
+      });
+    }),
+    // Empty custom circle hint
+    !isCollapsed && agents.length === 0 && React2.createElement("div", {
+      className: "px-8 py-2 text-[11px] text-ctp-overlay0 italic"
+    }, "Move agents here via right-click"),
+    // Agent context menu
+    agentContextMenu && React2.createElement(AgentContextMenu, {
+      position: agentContextMenu,
+      categories: allCategories,
+      currentCategoryId: category.id,
+      onMoveTo: (targetCategoryId) => onMoveAgent(agentContextMenu.agentId, targetCategoryId),
+      onCreateCircle: () => onCreateCircle(agentContextMenu.agentId),
+      onClose: () => setAgentContextMenu(null)
+    })
+  );
+}
+function EmptyState() {
+  return React2.createElement(
+    "div",
+    {
+      className: "flex items-center justify-center h-full text-center px-6"
+    },
+    React2.createElement(
+      "div",
+      null,
+      React2.createElement("p", { className: "text-ctp-subtext0 text-sm mb-1" }, "No agents yet"),
+      React2.createElement("p", { className: "text-ctp-overlay0 text-xs" }, "Agents will appear here grouped by project.")
+    )
+  );
+}
+function AgentContent({ api, agentId }) {
+  const agents = api.agents.list();
+  const agent = agents.find((a) => a.id === agentId);
+  if (!agent) {
+    return React2.createElement("div", {
+      className: "flex items-center justify-center h-full text-ctp-subtext0 text-sm"
+    }, "Agent not found");
+  }
+  const { AgentTerminal, SleepingAgent } = api.widgets;
+  if (agent.status === "sleeping" || agent.status === "error") {
+    return React2.createElement(SleepingAgent, { agentId: agent.id });
+  }
+  return React2.createElement(AgentTerminal, { agentId: agent.id, focused: true });
+}
+function NoSelection() {
+  return React2.createElement(
+    "div",
+    {
+      className: "flex items-center justify-center h-full text-center px-6",
+      "data-testid": "lounge-no-selection"
+    },
+    React2.createElement(
+      "div",
+      null,
+      React2.createElement("p", { className: "text-ctp-subtext0 text-sm mb-1" }, "Select an agent"),
+      React2.createElement("p", { className: "text-ctp-overlay0 text-xs" }, "Click an agent from the list to view it here.")
+    )
+  );
+}
+function MainPanel({ api }) {
+  const categories = useLoungeStore((s) => s.categories);
+  const collapsed = useLoungeStore((s) => s.collapsed);
+  const selectedAgentId = useLoungeStore((s) => s.selectedAgentId);
+  const deriveCategories = useLoungeStore((s) => s.deriveCategories);
+  const toggleCollapsed = useLoungeStore((s) => s.toggleCollapsed);
+  const selectAgent = useLoungeStore((s) => s.selectAgent);
+  const renameCategory = useLoungeStore((s) => s.renameCategory);
+  const moveAgent = useLoungeStore((s) => s.moveAgent);
+  const agentCategoryOverrides = useLoungeStore((s) => s.agentCategoryOverrides);
+  const addCircle = useLoungeStore((s) => s.addCircle);
+  const deleteCircle = useLoungeStore((s) => s.deleteCircle);
+  const reorderCategory = useLoungeStore((s) => s.reorderCategory);
+  const setCategoryEmoji = useLoungeStore((s) => s.setCategoryEmoji);
+  const loadPersistedState = useLoungeStore((s) => s.loadPersistedState);
+  const [loaded, setLoaded] = useState(false);
+  useEffect(() => {
+    api.storage.global.read(STORAGE_KEY).then((data) => {
+      if (data) loadPersistedState(data);
+      else useLoungeStore.setState({ hydrated: true });
+      setLoaded(true);
+    }).catch(() => {
+      useLoungeStore.setState({ hydrated: true });
+      setLoaded(true);
+    });
+  }, [api, loadPersistedState]);
+  const renamedLabels = useLoungeStore((s) => s.renamedLabels);
+  const customCircles = useLoungeStore((s) => s.customCircles);
+  const nextCircleId = useLoungeStore((s) => s.nextCircleId);
+  const categoryOrder = useLoungeStore((s) => s.categoryOrder);
+  const categoryEmojis = useLoungeStore((s) => s.categoryEmojis);
+  const saveTimerRef = useRef(null);
+  useEffect(() => {
+    if (!loaded) return;
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = setTimeout(() => {
+      const state = useLoungeStore.getState();
+      api.storage.global.write(STORAGE_KEY, getPersistedState(state)).catch(() => {
+      });
+    }, 500);
+    return () => {
+      if (saveTimerRef.current) {
+        clearTimeout(saveTimerRef.current);
+        const state = useLoungeStore.getState();
+        api.storage.global.write(STORAGE_KEY, getPersistedState(state)).catch(() => {
+        });
+      }
+    };
+  }, [api, loaded, renamedLabels, agentCategoryOverrides, customCircles, nextCircleId, categoryOrder, categoryEmojis, collapsed]);
+  const [agentTick, setAgentTick] = useState(0);
+  useEffect(() => {
+    const sub = api.agents.onAnyChange(() => setAgentTick((n) => n + 1));
+    return () => sub.dispose();
+  }, [api]);
+  const projects = useMemo(() => api.projects.list(), [api, agentTick]);
+  useEffect(() => {
+    deriveCategories(projects);
+  }, [projects, deriveCategories]);
+  const agents = useMemo(() => api.agents.list(), [api, agentTick]);
+  const grouped = useMemo(
+    () => groupAgentsByCategory(agents, categories, agentCategoryOverrides),
+    [agents, categories, agentCategoryOverrides]
+  );
+  const handleSelectAgent = useCallback((agentId, projectId) => {
+    selectAgent(agentId, projectId);
+  }, [selectAgent]);
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const [pendingMoveAgentId, setPendingMoveAgentId] = useState(null);
+  const [editingCircle, setEditingCircle] = useState(null);
+  const handleCreateCircle = useCallback((agentId) => {
+    setPendingMoveAgentId(agentId ?? null);
+    setShowCreateDialog(true);
+  }, []);
+  const handleConfirmCreate = useCallback((name, emoji) => {
+    const newId = addCircle(name);
+    if (newId) {
+      if (emoji && emoji !== DEFAULT_CUSTOM_EMOJI) {
+        setCategoryEmoji(newId, emoji);
+      }
+      if (pendingMoveAgentId) {
+        moveAgent(pendingMoveAgentId, newId);
+      }
+    }
+    setShowCreateDialog(false);
+    setPendingMoveAgentId(null);
+  }, [addCircle, moveAgent, setCategoryEmoji, pendingMoveAgentId]);
+  const handleEditCircle = useCallback((categoryId) => {
+    const cat = categories.find((c) => c.id === categoryId);
+    if (cat) {
+      setEditingCircle({ id: cat.id, label: cat.label, emoji: cat.emoji });
+    }
+  }, [categories]);
+  const handleConfirmEdit = useCallback((name, emoji) => {
+    if (editingCircle) {
+      if (name !== editingCircle.label) {
+        renameCategory(editingCircle.id, name);
+      }
+      if (emoji) {
+        setCategoryEmoji(editingCircle.id, emoji);
+      }
+    }
+    setEditingCircle(null);
+  }, [editingCircle, renameCategory, setCategoryEmoji]);
+  useEffect(() => {
+    if (selectedAgentId && !agents.find((a) => a.id === selectedAgentId)) {
+      selectAgent(null);
+    }
+  }, [agents, selectedAgentId, selectAgent]);
+  useEffect(() => {
+    if (!loaded || agents.length === 0) return;
+    for (const cat of categories) {
+      if (cat.projectId || isDefaultCircle(cat.id)) continue;
+      const catAgents = grouped.get(cat.id) ?? [];
+      if (catAgents.length === 0) {
+        deleteCircle(cat.id);
+      }
+    }
+  }, [grouped, categories, deleteCircle, loaded, agents.length]);
+  const hasAgents = agents.length > 0;
+  const visibleCategories = categories.filter((cat) => {
+    if (cat.projectId) {
+      const catAgents = grouped.get(cat.id) ?? [];
+      return catAgents.length > 0;
+    }
+    return true;
+  });
+  return React2.createElement(
+    "div",
+    {
+      className: "flex h-full w-full bg-ctp-base",
+      "data-testid": "lounge-main-panel"
+    },
+    // Left sidebar — agent list
+    React2.createElement(
+      "div",
+      {
+        className: "w-64 flex-shrink-0 flex flex-col bg-ctp-mantle border-r border-surface-0 h-full min-h-0"
+      },
+      // Header
+      React2.createElement(
+        "div",
+        {
+          className: "px-3 py-3 border-b border-surface-0"
+        },
+        React2.createElement("h2", {
+          className: "text-xs font-semibold text-ctp-subtext0 uppercase tracking-wider"
+        }, "Lounge")
+      ),
+      // Scrollable category list
+      React2.createElement(
+        "div",
+        {
+          className: "flex-1 overflow-y-auto py-1",
+          "data-testid": "lounge-category-list"
+        },
+        hasAgents || categories.some((c) => !c.projectId) ? visibleCategories.map((cat) => {
+          const catAgents = grouped.get(cat.id) ?? [];
+          return React2.createElement(CategorySection, {
+            key: cat.id,
+            category: cat,
+            agents: catAgents,
+            allAgents: agents,
+            allCategories: categories,
+            projects,
+            isCollapsed: collapsed.has(cat.id),
+            selectedAgentId,
+            onToggle: () => toggleCollapsed(cat.id),
+            onSelectAgent: handleSelectAgent,
+            onEditCircle: handleEditCircle,
+            onDelete: deleteCircle,
+            onMoveAgent: moveAgent,
+            onCreateCircle: handleCreateCircle,
+            onReorderCategory: reorderCategory
+          });
+        }) : React2.createElement(EmptyState)
+      )
+    ),
+    // Right content — selected agent view
+    React2.createElement(
+      "div",
+      {
+        className: "flex-1 min-w-0 h-full"
+      },
+      selectedAgentId ? React2.createElement(AgentContent, { api, agentId: selectedAgentId }) : React2.createElement(NoSelection)
+    ),
+    // Circle dialog (create or edit mode)
+    showCreateDialog && React2.createElement(CircleDialog, {
+      mode: "create",
+      onConfirm: handleConfirmCreate,
+      onCancel: () => setShowCreateDialog(false),
+      existingCategories: categories
+    }),
+    editingCircle && React2.createElement(CircleDialog, {
+      mode: "edit",
+      onConfirm: handleConfirmEdit,
+      onCancel: () => setEditingCircle(null),
+      existingCategories: categories,
+      initialName: editingCircle.label,
+      initialEmoji: editingCircle.emoji,
+      editCategoryId: editingCircle.id
+    })
+  );
+}
+export {
+  MainPanel,
+  activate,
+  deactivate
+};

--- a/plugins/lounge/dist/main.js
+++ b/plugins/lounge/dist/main.js
@@ -723,7 +723,8 @@ function CircleDialog({ mode, onConfirm, onCancel, existingCategories, initialNa
       showEmojis && React2.createElement(
         "div",
         {
-          className: "mt-2 p-2 rounded-lg bg-ctp-base border border-surface-1 grid grid-cols-8 gap-1",
+          className: "mt-2 p-2 rounded-lg bg-ctp-base border border-surface-1",
+          style: { display: "grid", gridTemplateColumns: "repeat(8, 1fr)", gap: "4px" },
           "data-testid": "lounge-circle-dialog-emoji-picker"
         },
         ...EMOJI_OPTIONS.map(

--- a/plugins/lounge/manifest.json
+++ b/plugins/lounge/manifest.json
@@ -1,0 +1,29 @@
+{
+  "id": "lounge",
+  "name": "Lounge",
+  "version": "1.0.0",
+  "description": "Chat-style agent browser — hop between agents organized by project circles.",
+  "author": "Clubhouse Workshop",
+  "engine": { "api": 0.8 },
+  "scope": "app",
+  "main": "./dist/main.js",
+  "permissions": ["agents", "projects", "navigation", "widgets", "commands", "storage"],
+  "contributes": {
+    "railItem": {
+      "label": "Lounge",
+      "icon": "<svg width='18' height='18' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'><path d='M4 11V8a4 4 0 0 1 4-4h8a4 4 0 0 1 4 4v3'/><path d='M2 11v4a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-4a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2z'/><path d='M6 17v2'/><path d='M18 17v2'/></svg>",
+      "position": "top"
+    },
+    "commands": [],
+    "storage": { "scope": "global" },
+    "help": {
+      "topics": [
+        {
+          "id": "lounge-overview",
+          "title": "Lounge",
+          "content": "## Lounge\n\nThe Lounge provides a chat-style sidebar for quickly browsing and hopping between agents across all projects.\n\n### Circles\nAgents are grouped into collapsible circles — by default, one per project. Create custom circles, assign emojis, and drag agents between them.\n\n### Features\n- Right-click agents to move between circles\n- Right-click circles to rename or delete\n- Drag-and-drop agents and reorder circles\n- Emoji icons for circles\n- Configuration persists across sessions\n\n### Disambiguation\nWhen multiple agents share a name, they are shown as **project/agent** to avoid confusion."
+        }
+      ]
+    }
+  }
+}

--- a/plugins/lounge/package.json
+++ b/plugins/lounge/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "lounge",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "description": "Chat-style agent browser — hop between agents organized by project circles",
+  "scripts": {
+    "build": "node build.cjs",
+    "watch": "node build.cjs --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@clubhouse/plugin-testing": "file:../../sdk/v0.8/plugin-testing",
+    "@clubhouse/plugin-types": "file:../../sdk/v0.8/plugin-types",
+    "@clubhouse/plugin-utils": "file:../../sdk/shared/plugin-utils",
+    "@types/react": "^19.0.0",
+    "esbuild": "^0.24.0",
+    "react": "^19.2.4",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0",
+    "zustand": "^5.0.0"
+  }
+}

--- a/plugins/lounge/src/main.test.ts
+++ b/plugins/lounge/src/main.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest';
+import * as loungeModule from './main';
+import { createMockContext, createMockAPI } from '@clubhouse/plugin-testing';
+
+describe('lounge main', () => {
+  it('exports required PluginModule members', () => {
+    expect(loungeModule.activate).toBeDefined();
+    expect(typeof loungeModule.activate).toBe('function');
+    expect(loungeModule.deactivate).toBeDefined();
+    expect(typeof loungeModule.deactivate).toBe('function');
+    expect(loungeModule.MainPanel).toBeDefined();
+    expect(typeof loungeModule.MainPanel).toBe('function');
+  });
+
+  it('activate does not throw', () => {
+    const ctx = createMockContext({ pluginId: 'lounge', scope: 'app' });
+    const api = createMockAPI({
+      context: { mode: 'app' },
+    });
+
+    expect(() => loungeModule.activate(ctx, api)).not.toThrow();
+  });
+
+  it('deactivate does not throw', () => {
+    expect(() => loungeModule.deactivate()).not.toThrow();
+  });
+
+  it('exports MainPanel component', () => {
+    expect(loungeModule.MainPanel).toBeDefined();
+    expect(typeof loungeModule.MainPanel).toBe('function');
+  });
+});

--- a/plugins/lounge/src/main.ts
+++ b/plugins/lounge/src/main.ts
@@ -699,6 +699,23 @@ function AgentContent({ api, agentId }: { api: PluginAPI; agentId: string }) {
   const agents = api.agents.list();
   const agent = agents.find((a) => a.id === agentId);
 
+  // Track focus with false→true transition on agent switch (mirrors MainContentView pattern)
+  const [terminalFocused, setTerminalFocused] = useState(false);
+  const prevAgentIdRef = useRef(agentId);
+
+  useEffect(() => {
+    const agentChanged = prevAgentIdRef.current !== agentId;
+    prevAgentIdRef.current = agentId;
+
+    if (agentChanged) {
+      setTerminalFocused(false);
+      const raf = requestAnimationFrame(() => setTerminalFocused(true));
+      return () => cancelAnimationFrame(raf);
+    }
+
+    setTerminalFocused(true);
+  }, [agentId]);
+
   if (!agent) {
     return React.createElement('div', {
       className: 'flex items-center justify-center h-full text-ctp-subtext0 text-sm',
@@ -711,7 +728,7 @@ function AgentContent({ api, agentId }: { api: PluginAPI; agentId: string }) {
     return React.createElement(SleepingAgent, { agentId: agent.id });
   }
 
-  return React.createElement(AgentTerminal, { agentId: agent.id, focused: true });
+  return React.createElement(AgentTerminal, { agentId: agent.id, focused: terminalFocused });
 }
 
 // ── No Selection Placeholder ───────────────────────────────────────────

--- a/plugins/lounge/src/main.ts
+++ b/plugins/lounge/src/main.ts
@@ -607,7 +607,12 @@ function CategorySection({ category, agents, allAgents, allCategories, projects,
       isCollapsed ? CHEVRON_RIGHT : CHEVRON_DOWN,
       React.createElement('span', { className: 'text-sm flex-shrink-0' }, category.emoji || '📁'),
       React.createElement('span', { className: 'flex-1 text-left truncate' }, category.label),
-      React.createElement('span', { className: 'text-[10px] text-ctp-overlay0 tabular-nums' }, String(agents.length)),
+      React.createElement('span', { className: 'text-[10px] text-ctp-overlay0 tabular-nums' },
+        (() => {
+          const active = agents.filter((a) => a.status === 'running' || a.status === 'waking' || a.status === 'creating').length;
+          return active > 0 ? `${active}/${agents.length}` : String(agents.length);
+        })(),
+      ),
     ),
     // Context menu
     contextMenu && React.createElement(CategoryContextMenu, {

--- a/plugins/lounge/src/main.ts
+++ b/plugins/lounge/src/main.ts
@@ -708,11 +708,13 @@ export function MainPanel({ api }: { api: PluginAPI }) {
     return () => sub.dispose();
   }, [api]);
 
-  // Derive categories from projects
+  // Derive categories from projects (only after persisted state is loaded
+  // to avoid overriding circle assignments with default project grouping)
   const projects = useMemo(() => api.projects.list(), [api, agentTick]);
   useEffect(() => {
+    if (!loaded) return;
     deriveCategories(projects);
-  }, [projects, deriveCategories]);
+  }, [projects, deriveCategories, loaded]);
 
   // Get all agents across projects
   const agents = useMemo(() => api.agents.list(), [api, agentTick]);

--- a/plugins/lounge/src/main.ts
+++ b/plugins/lounge/src/main.ts
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState, useCallback, useRef } from 'react';
 import type { PluginContext, PluginAPI, PluginModule, AgentInfo } from '@clubhouse/plugin-types';
-import { createLoungeStore, groupAgentsByCategory, disambiguateAgentName, isDefaultCircle, isReservedCircleName, isDuplicateCircleName, getPersistedState, DEFAULT_CUSTOM_EMOJI } from './state';
+import { createLoungeStore, groupAgentsByCategory, sortAgentsByOrder, disambiguateAgentName, isDefaultCircle, isReservedCircleName, isDuplicateCircleName, getPersistedState, DEFAULT_CUSTOM_EMOJI } from './state';
 import type { LoungeCategory, LoungePersistedState } from './state';
 
 const useLoungeStore = createLoungeStore();
@@ -471,7 +471,7 @@ function CircleDialog({ mode, onConfirm, onCancel, existingCategories, initialNa
   );
 }
 
-function CategorySection({ category, agents, allAgents, allCategories, projects, isCollapsed, selectedAgentId, onToggle, onSelectAgent, onEditCircle, onDelete, onMoveAgent, onCreateCircle, onReorderCategory }: {
+function CategorySection({ category, agents, allAgents, allCategories, projects, isCollapsed, selectedAgentId, onToggle, onSelectAgent, onEditCircle, onDelete, onMoveAgent, onPlaceAgent, onCreateCircle, onReorderCategory }: {
   category: LoungeCategory;
   agents: AgentInfo[];
   allAgents: AgentInfo[];
@@ -484,6 +484,7 @@ function CategorySection({ category, agents, allAgents, allCategories, projects,
   onEditCircle: (categoryId: string) => void;
   onDelete: (categoryId: string) => void;
   onMoveAgent: (agentId: string, targetCategoryId: string) => void;
+  onPlaceAgent: (agentId: string, targetCategoryId: string, beforeAgentId: string | null) => void;
   onCreateCircle: (agentId?: string) => void;
   onReorderCategory: (fromId: string, toId: string) => void;
 }) {
@@ -527,14 +528,15 @@ function CategorySection({ category, agents, allAgents, allCategories, projects,
     setDragOver(false);
     const agentId = e.dataTransfer.getData('application/x-lounge-agent');
     if (agentId) {
-      onMoveAgent(agentId, category.id);
+      // Agent dropped on category header/whitespace — move to end of this circle
+      onPlaceAgent(agentId, category.id, null);
       return;
     }
     const fromCategoryId = e.dataTransfer.getData('application/x-lounge-category');
     if (fromCategoryId && fromCategoryId !== category.id && !isGeneralCircle) {
       onReorderCategory(fromCategoryId, category.id);
     }
-  }, [category.id, onMoveAgent, onReorderCategory, isGeneralCircle]);
+  }, [category.id, onPlaceAgent, onReorderCategory, isGeneralCircle]);
 
   return React.createElement('div', {
     'data-testid': `lounge-category-${category.id}`,
@@ -567,19 +569,40 @@ function CategorySection({ category, agents, allAgents, allCategories, projects,
       onClose: () => setContextMenu(null),
     }),
     // Agent rows (hidden when collapsed)
-    !isCollapsed && agents.length > 0 && agents.map((agent) => {
+    !isCollapsed && agents.length > 0 && agents.map((agent, idx) => {
       const displayName = disambiguateAgentName(agent, allAgents, projects);
-      return React.createElement(AgentRow, {
+      const nextAgentId = idx < agents.length - 1 ? agents[idx + 1].id : null;
+      return React.createElement('div', {
         key: agent.id,
-        agent,
-        displayName,
-        isSelected: selectedAgentId === agent.id,
-        onClick: () => onSelectAgent(agent.id, agent.projectId),
-        onContextMenu: (e: React.MouseEvent) => {
+        onDragOver: (e: React.DragEvent) => {
+          if (!e.dataTransfer.types.includes('application/x-lounge-agent')) return;
           e.preventDefault();
-          setAgentContextMenu({ agentId: agent.id, x: e.clientX, y: e.clientY });
+          e.stopPropagation();
+          e.dataTransfer.dropEffect = 'move';
         },
-      });
+        onDrop: (e: React.DragEvent) => {
+          const draggedId = e.dataTransfer.getData('application/x-lounge-agent');
+          if (!draggedId || draggedId === agent.id) return;
+          e.preventDefault();
+          e.stopPropagation();
+          // Determine insert position based on mouse Y relative to element midpoint
+          const rect = e.currentTarget.getBoundingClientRect();
+          const isUpperHalf = e.clientY < rect.top + rect.height / 2;
+          const beforeId = isUpperHalf ? agent.id : nextAgentId;
+          onPlaceAgent(draggedId, category.id, beforeId);
+        },
+      },
+        React.createElement(AgentRow, {
+          agent,
+          displayName,
+          isSelected: selectedAgentId === agent.id,
+          onClick: () => onSelectAgent(agent.id, agent.projectId),
+          onContextMenu: (e: React.MouseEvent) => {
+            e.preventDefault();
+            setAgentContextMenu({ agentId: agent.id, x: e.clientX, y: e.clientY });
+          },
+        }),
+      );
     }),
     // Empty custom circle hint
     !isCollapsed && agents.length === 0 && React.createElement('div', {
@@ -661,6 +684,8 @@ export function MainPanel({ api }: { api: PluginAPI }) {
   const deleteCircle = useLoungeStore((s) => s.deleteCircle);
   const reorderCategory = useLoungeStore((s) => s.reorderCategory);
   const setCategoryEmoji = useLoungeStore((s) => s.setCategoryEmoji);
+  const placeAgent = useLoungeStore((s) => s.placeAgent);
+  const agentOrder = useLoungeStore((s) => s.agentOrder);
   const loadPersistedState = useLoungeStore((s) => s.loadPersistedState);
 
   // Load persisted state on mount
@@ -699,7 +724,7 @@ export function MainPanel({ api }: { api: PluginAPI }) {
         api.storage.global.write(STORAGE_KEY, getPersistedState(state)).catch(() => {});
       }
     };
-  }, [api, loaded, renamedLabels, agentCategoryOverrides, customCircles, nextCircleId, categoryOrder, categoryEmojis, collapsed]);
+  }, [api, loaded, renamedLabels, agentCategoryOverrides, customCircles, nextCircleId, categoryOrder, categoryEmojis, agentOrder, collapsed]);
 
   // Force re-render when agents change
   const [agentTick, setAgentTick] = useState(0);
@@ -825,7 +850,7 @@ export function MainPanel({ api }: { api: PluginAPI }) {
       },
         hasAgents || categories.some((c) => !c.projectId)
           ? visibleCategories.map((cat) => {
-              const catAgents = grouped.get(cat.id) ?? [];
+              const catAgents = sortAgentsByOrder(grouped.get(cat.id) ?? [], agentOrder[cat.id]);
               return React.createElement(CategorySection, {
                 key: cat.id,
                 category: cat,
@@ -840,6 +865,7 @@ export function MainPanel({ api }: { api: PluginAPI }) {
                 onEditCircle: handleEditCircle,
                 onDelete: deleteCircle,
                 onMoveAgent: moveAgent,
+                onPlaceAgent: placeAgent,
                 onCreateCircle: handleCreateCircle,
                 onReorderCategory: reorderCategory,
               });

--- a/plugins/lounge/src/main.ts
+++ b/plugins/lounge/src/main.ts
@@ -150,8 +150,10 @@ function CategoryContextMenu({ position, categoryId, onRename, onDelete, onClose
 
 // ── Agent Context Menu ──────────────────────────────────────────────────
 
-function AgentContextMenu({ position, categories, currentCategoryId, onMoveTo, onCreateCircle, onClose }: {
+function AgentContextMenu({ position, agent, api, categories, currentCategoryId, onMoveTo, onCreateCircle, onClose }: {
   position: { x: number; y: number };
+  agent: AgentInfo;
+  api: PluginAPI;
   categories: LoungeCategory[];
   currentCategoryId: string;
   onMoveTo: (categoryId: string) => void;
@@ -198,12 +200,58 @@ function AgentContextMenu({ position, categories, currentCategoryId, onMoveTo, o
     return { left: x, top: y };
   }, [showSubmenu, categories.length]);
 
+  const isRunning = agent.status === 'running' || agent.status === 'waking' || agent.status === 'creating';
+  const isSleeping = agent.status === 'sleeping';
+
+  const menuItemClass = 'w-full flex items-center gap-2 px-3 py-1.5 text-xs text-ctp-subtext0 hover:bg-surface-1 hover:text-ctp-text transition-colors cursor-pointer';
+
   return React.createElement('div', {
     ref: menuRef,
     className: 'fixed z-50 min-w-[160px] py-1 rounded-lg shadow-xl border border-surface-1 bg-ctp-mantle',
     style,
     'data-testid': 'lounge-agent-context-menu',
   },
+    // ── Agent lifecycle actions ──
+    isRunning && React.createElement('button', {
+      className: menuItemClass,
+      onClick: () => { api.agents.kill(agent.id).catch(() => {}); onClose(); },
+      'data-testid': 'lounge-ctx-stop',
+    },
+      React.createElement('svg', {
+        width: 12, height: 12, viewBox: '0 0 24 24', fill: 'none',
+        stroke: 'currentColor', strokeWidth: 2, strokeLinecap: 'round', strokeLinejoin: 'round',
+      }, React.createElement('rect', { x: '6', y: '6', width: '12', height: '12', rx: '1' })),
+      React.createElement('span', null, 'Stop'),
+    ),
+    isSleeping && React.createElement('button', {
+      className: menuItemClass,
+      onClick: () => { api.agents.resume(agent.id).catch(() => {}); onClose(); },
+      'data-testid': 'lounge-ctx-wake',
+    },
+      React.createElement('svg', {
+        width: 12, height: 12, viewBox: '0 0 24 24', fill: 'none',
+        stroke: 'currentColor', strokeWidth: 2, strokeLinecap: 'round', strokeLinejoin: 'round',
+      }, React.createElement('polygon', { points: '5 3 19 12 5 21 5 3' })),
+      React.createElement('span', null, 'Wake'),
+    ),
+    // Pop Out
+    React.createElement('button', {
+      className: menuItemClass,
+      onClick: () => { api.navigation.popOutAgent(agent.id).catch(() => {}); onClose(); },
+      'data-testid': 'lounge-ctx-popout',
+    },
+      React.createElement('svg', {
+        width: 12, height: 12, viewBox: '0 0 24 24', fill: 'none',
+        stroke: 'currentColor', strokeWidth: 2, strokeLinecap: 'round', strokeLinejoin: 'round',
+      },
+        React.createElement('path', { d: 'M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6' }),
+        React.createElement('polyline', { points: '15 3 21 3 21 9' }),
+        React.createElement('line', { x1: '10', y1: '14', x2: '21', y2: '3' }),
+      ),
+      React.createElement('span', null, 'Pop Out'),
+    ),
+    // Divider between lifecycle and circle actions
+    React.createElement('div', { className: 'mx-2 my-1 border-t border-surface-1' }),
     // "Move to" with submenu
     React.createElement('div', { className: 'relative' },
       React.createElement('button', {
@@ -471,7 +519,7 @@ function CircleDialog({ mode, onConfirm, onCancel, existingCategories, initialNa
   );
 }
 
-function CategorySection({ category, agents, allAgents, allCategories, projects, isCollapsed, selectedAgentId, onToggle, onSelectAgent, onEditCircle, onDelete, onMoveAgent, onPlaceAgent, onCreateCircle, onReorderCategory }: {
+function CategorySection({ category, agents, allAgents, allCategories, projects, isCollapsed, selectedAgentId, api, onToggle, onSelectAgent, onEditCircle, onDelete, onMoveAgent, onPlaceAgent, onCreateCircle, onReorderCategory }: {
   category: LoungeCategory;
   agents: AgentInfo[];
   allAgents: AgentInfo[];
@@ -479,6 +527,7 @@ function CategorySection({ category, agents, allAgents, allCategories, projects,
   projects: { id: string; name: string; path: string }[];
   isCollapsed: boolean;
   selectedAgentId: string | null;
+  api: PluginAPI;
   onToggle: () => void;
   onSelectAgent: (agentId: string, projectId: string) => void;
   onEditCircle: (categoryId: string) => void;
@@ -609,14 +658,20 @@ function CategorySection({ category, agents, allAgents, allCategories, projects,
       className: 'px-8 py-2 text-[11px] text-ctp-overlay0 italic',
     }, 'Move agents here via right-click'),
     // Agent context menu
-    agentContextMenu && React.createElement(AgentContextMenu, {
-      position: agentContextMenu,
-      categories: allCategories,
-      currentCategoryId: category.id,
-      onMoveTo: (targetCategoryId: string) => onMoveAgent(agentContextMenu.agentId, targetCategoryId),
-      onCreateCircle: () => onCreateCircle(agentContextMenu.agentId),
-      onClose: () => setAgentContextMenu(null),
-    }),
+    agentContextMenu && (() => {
+      const ctxAgent = agents.find((a) => a.id === agentContextMenu.agentId) ?? allAgents.find((a) => a.id === agentContextMenu.agentId);
+      if (!ctxAgent) return null;
+      return React.createElement(AgentContextMenu, {
+        position: agentContextMenu,
+        agent: ctxAgent,
+        api,
+        categories: allCategories,
+        currentCategoryId: category.id,
+        onMoveTo: (targetCategoryId: string) => onMoveAgent(agentContextMenu.agentId, targetCategoryId),
+        onCreateCircle: () => onCreateCircle(agentContextMenu.agentId),
+        onClose: () => setAgentContextMenu(null),
+      });
+    })(),
   );
 }
 
@@ -860,6 +915,7 @@ export function MainPanel({ api }: { api: PluginAPI }) {
                 projects,
                 isCollapsed: collapsed.has(cat.id),
                 selectedAgentId,
+                api,
                 onToggle: () => toggleCollapsed(cat.id),
                 onSelectAgent: handleSelectAgent,
                 onEditCircle: handleEditCircle,

--- a/plugins/lounge/src/main.ts
+++ b/plugins/lounge/src/main.ts
@@ -1,7 +1,8 @@
 import React, { useEffect, useMemo, useState, useCallback, useRef } from 'react';
-import type { PluginContext, PluginAPI, PluginModule, AgentInfo } from '@clubhouse/plugin-types';
+import type { PluginContext, PluginAPI, PluginModule, AgentInfo, PluginOrchestratorInfo } from '@clubhouse/plugin-types';
 import { createLoungeStore, groupAgentsByCategory, sortAgentsByOrder, disambiguateAgentName, isDefaultCircle, isReservedCircleName, isDuplicateCircleName, getPersistedState, DEFAULT_CUSTOM_EMOJI } from './state';
 import type { LoungeCategory, LoungePersistedState } from './state';
+import { getOrchestratorColor, getOrchestratorLabel, formatModelLabel, getModelTagColor, FREE_AGENT_COLOR } from './tag-helpers';
 
 const useLoungeStore = createLoungeStore();
 
@@ -40,10 +41,12 @@ function statusLabel(status: AgentInfo['status']): string {
 
 // ── Agent Row ──────────────────────────────────────────────────────────
 
-function AgentRow({ agent, displayName, isSelected, onClick, onContextMenu }: {
+function AgentRow({ agent, displayName, isSelected, showTags, orchestrators, onClick, onContextMenu }: {
   agent: AgentInfo;
   displayName: string;
   isSelected: boolean;
+  showTags: boolean;
+  orchestrators: PluginOrchestratorInfo[];
   onClick: () => void;
   onContextMenu: (e: React.MouseEvent) => void;
 }) {
@@ -69,7 +72,36 @@ function AgentRow({ agent, displayName, isSelected, onClick, onContextMenu }: {
     React.createElement('span', {
       className: `w-2 h-2 rounded-full flex-shrink-0 ${statusColor(agent.status)}`,
     }),
-    React.createElement('span', { className: 'truncate flex-1' }, displayName),
+    React.createElement('div', { className: 'min-w-0 flex-1' },
+      React.createElement('span', { className: 'truncate block' }, displayName),
+      showTags && React.createElement('div', {
+        className: 'flex items-center gap-1 mt-0.5 flex-wrap',
+        'data-testid': `lounge-agent-tags-${agent.id}`,
+      },
+        // Provider tag
+        agent.orchestrator && (() => {
+          const c = getOrchestratorColor(agent.orchestrator);
+          return React.createElement('span', {
+            style: { backgroundColor: c.bg, color: c.text, fontSize: '10px', padding: '1px 6px', borderRadius: '4px', lineHeight: '16px', whiteSpace: 'nowrap' as const },
+            'data-testid': 'lounge-tag-provider',
+          }, getOrchestratorLabel(agent.orchestrator, orchestrators));
+        })(),
+        // Model tag
+        (() => {
+          const label = formatModelLabel(agent.model);
+          const c = getModelTagColor(agent.model);
+          return React.createElement('span', {
+            style: { backgroundColor: c.bg, color: c.text, fontSize: '10px', padding: '1px 6px', borderRadius: '4px', lineHeight: '16px', fontFamily: 'monospace', whiteSpace: 'nowrap' as const },
+            'data-testid': 'lounge-tag-model',
+          }, label);
+        })(),
+        // Free Agent tag
+        agent.freeAgentMode && React.createElement('span', {
+          style: { backgroundColor: FREE_AGENT_COLOR.bg, color: FREE_AGENT_COLOR.text, fontSize: '10px', padding: '1px 6px', borderRadius: '4px', lineHeight: '16px', whiteSpace: 'nowrap' as const },
+          'data-testid': 'lounge-tag-free',
+        }, 'Free'),
+      ),
+    ),
     agent.status === 'running' && React.createElement('span', {
       className: 'text-[10px] text-ctp-green flex-shrink-0',
     }, '●'),
@@ -519,7 +551,7 @@ function CircleDialog({ mode, onConfirm, onCancel, existingCategories, initialNa
   );
 }
 
-function CategorySection({ category, agents, allAgents, allCategories, projects, isCollapsed, selectedAgentId, api, onToggle, onSelectAgent, onEditCircle, onDelete, onMoveAgent, onPlaceAgent, onCreateCircle, onReorderCategory }: {
+function CategorySection({ category, agents, allAgents, allCategories, projects, isCollapsed, selectedAgentId, showTags, orchestrators, api, onToggle, onSelectAgent, onEditCircle, onDelete, onMoveAgent, onPlaceAgent, onCreateCircle, onReorderCategory }: {
   category: LoungeCategory;
   agents: AgentInfo[];
   allAgents: AgentInfo[];
@@ -527,6 +559,8 @@ function CategorySection({ category, agents, allAgents, allCategories, projects,
   projects: { id: string; name: string; path: string }[];
   isCollapsed: boolean;
   selectedAgentId: string | null;
+  showTags: boolean;
+  orchestrators: PluginOrchestratorInfo[];
   api: PluginAPI;
   onToggle: () => void;
   onSelectAgent: (agentId: string, projectId: string) => void;
@@ -650,6 +684,8 @@ function CategorySection({ category, agents, allAgents, allCategories, projects,
           agent,
           displayName,
           isSelected: selectedAgentId === agent.id,
+          showTags,
+          orchestrators,
           onClick: () => onSelectAgent(agent.id, agent.projectId),
           onContextMenu: (e: React.MouseEvent) => {
             e.preventDefault();
@@ -677,6 +713,105 @@ function CategorySection({ category, agents, allAgents, allCategories, projects,
         onClose: () => setAgentContextMenu(null),
       });
     })(),
+  );
+}
+
+// ── Resize Divider ─────────────────────────────────────────────────────
+
+interface ResizeDividerProps {
+  onResize: (delta: number) => void;
+  onToggleCollapse: () => void;
+  collapsed: boolean;
+}
+
+function ResizeDivider({ onResize, onToggleCollapse, collapsed }: ResizeDividerProps) {
+  const [hovered, setHovered] = useState(false);
+  const draggingRef = useRef(false);
+  const startXRef = useRef(0);
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    draggingRef.current = true;
+    startXRef.current = e.clientX;
+    document.body.style.userSelect = 'none';
+    document.body.style.cursor = 'col-resize';
+
+    const handleMouseMove = (ev: MouseEvent) => {
+      const delta = ev.clientX - startXRef.current;
+      if (delta !== 0) {
+        onResize(delta);
+        startXRef.current = ev.clientX;
+      }
+    };
+
+    const handleMouseUp = () => {
+      draggingRef.current = false;
+      document.body.style.userSelect = '';
+      document.body.style.cursor = '';
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+  }, [onResize]);
+
+  const handleDoubleClick = useCallback(() => {
+    onToggleCollapse();
+  }, [onToggleCollapse]);
+
+  const chevron = collapsed ? '\u25B6' : '\u25C0';
+
+  return React.createElement('div', {
+    style: {
+      width: 5,
+      cursor: 'col-resize',
+      position: 'relative' as const,
+      flexShrink: 0,
+    },
+    onMouseDown: handleMouseDown,
+    onDoubleClick: handleDoubleClick,
+    onMouseEnter: () => setHovered(true),
+    onMouseLeave: () => setHovered(false),
+    'data-testid': 'lounge-sidebar-edge',
+  },
+    // Visible center line
+    React.createElement('div', {
+      style: {
+        position: 'absolute' as const,
+        top: 0,
+        bottom: 0,
+        left: '50%',
+        transform: 'translateX(-50%)',
+        width: 1,
+        backgroundColor: hovered ? 'rgba(137, 180, 250, 0.6)' : 'rgba(88, 91, 112, 0.5)',
+        transition: 'background-color 100ms',
+      },
+    }),
+    // Chevron button — only visible on hover
+    hovered && React.createElement('button', {
+      onClick: (e: React.MouseEvent) => { e.stopPropagation(); onToggleCollapse(); },
+      style: {
+        position: 'absolute' as const,
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+        width: 16,
+        height: 16,
+        borderRadius: '50%',
+        backgroundColor: '#1e1e2e',
+        border: '1px solid rgba(88, 91, 112, 0.5)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: '8px',
+        color: '#a6adc8',
+        cursor: 'pointer',
+        padding: 0,
+        zIndex: 10,
+      },
+      'data-testid': 'lounge-collapse-sidebar',
+    }, chevron),
   );
 }
 
@@ -764,6 +899,12 @@ export function MainPanel({ api }: { api: PluginAPI }) {
   const placeAgent = useLoungeStore((s) => s.placeAgent);
   const agentOrder = useLoungeStore((s) => s.agentOrder);
   const loadPersistedState = useLoungeStore((s) => s.loadPersistedState);
+  const showTags = useLoungeStore((s) => s.showTags);
+  const toggleShowTags = useLoungeStore((s) => s.toggleShowTags);
+  const sidebarCollapsed = useLoungeStore((s) => s.sidebarCollapsed);
+  const toggleSidebar = useLoungeStore((s) => s.toggleSidebar);
+  const sidebarWidth = useLoungeStore((s) => s.sidebarWidth);
+  const setSidebarWidth = useLoungeStore((s) => s.setSidebarWidth);
 
   // Load persisted state on mount
   const [loaded, setLoaded] = useState(false);
@@ -801,7 +942,7 @@ export function MainPanel({ api }: { api: PluginAPI }) {
         api.storage.global.write(STORAGE_KEY, getPersistedState(state)).catch(() => {});
       }
     };
-  }, [api, loaded, renamedLabels, agentCategoryOverrides, customCircles, nextCircleId, categoryOrder, categoryEmojis, agentOrder, collapsed]);
+  }, [api, loaded, renamedLabels, agentCategoryOverrides, customCircles, nextCircleId, categoryOrder, categoryEmojis, agentOrder, collapsed, showTags, sidebarCollapsed, sidebarWidth]);
 
   // Force re-render when agents change
   const [agentTick, setAgentTick] = useState(0);
@@ -820,6 +961,9 @@ export function MainPanel({ api }: { api: PluginAPI }) {
 
   // Get all agents across projects
   const agents = useMemo(() => api.agents.list(), [api, agentTick]);
+
+  // Fetch orchestrator list once for tag labels
+  const orchestrators = useMemo(() => api.agents.listOrchestrators(), [api]);
 
   // Group agents by category (respecting overrides)
   const grouped = useMemo(
@@ -908,17 +1052,41 @@ export function MainPanel({ api }: { api: PluginAPI }) {
     className: 'flex h-full w-full bg-ctp-base',
     'data-testid': 'lounge-main-panel',
   },
-    // Left sidebar — agent list
+    // Left sidebar — agent list (collapsible)
     React.createElement('div', {
-      className: 'w-64 flex-shrink-0 flex flex-col bg-ctp-mantle border-r border-surface-0 h-full min-h-0',
+      style: {
+        width: sidebarCollapsed ? '0px' : `${sidebarWidth}px`,
+        minWidth: 0,
+        transition: 'width 200ms ease-in-out',
+        overflow: 'hidden',
+        flexShrink: 0,
+      },
+      className: 'flex flex-col bg-ctp-mantle h-full min-h-0',
+      'data-testid': 'lounge-sidebar',
     },
       // Header
       React.createElement('div', {
-        className: 'px-3 py-3 border-b border-surface-0',
+        className: 'px-3 py-3 border-b border-surface-0 flex items-center gap-2',
       },
         React.createElement('h2', {
-          className: 'text-xs font-semibold text-ctp-subtext0 uppercase tracking-wider',
+          className: 'text-xs font-semibold text-ctp-subtext0 uppercase tracking-wider flex-1',
         }, 'Lounge'),
+        // Tags toggle button
+        React.createElement('button', {
+          onClick: toggleShowTags,
+          title: showTags ? 'Hide tags' : 'Show tags',
+          className: 'w-5 h-5 flex items-center justify-center rounded text-ctp-overlay0 hover:text-ctp-text hover:bg-surface-0 cursor-pointer transition-colors',
+          'data-testid': 'lounge-toggle-tags',
+        },
+          React.createElement('svg', {
+            width: 12, height: 12, viewBox: '0 0 24 24', fill: 'none',
+            stroke: 'currentColor', strokeWidth: 2, strokeLinecap: 'round', strokeLinejoin: 'round',
+            style: { opacity: showTags ? 1 : 0.4 },
+          },
+            React.createElement('path', { d: 'M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z' }),
+            React.createElement('line', { x1: '7', y1: '7', x2: '7.01', y2: '7' }),
+          ),
+        ),
       ),
       // Scrollable category list
       React.createElement('div', {
@@ -937,6 +1105,8 @@ export function MainPanel({ api }: { api: PluginAPI }) {
                 projects,
                 isCollapsed: collapsed.has(cat.id),
                 selectedAgentId,
+                showTags,
+                orchestrators,
                 api,
                 onToggle: () => toggleCollapsed(cat.id),
                 onSelectAgent: handleSelectAgent,
@@ -951,6 +1121,15 @@ export function MainPanel({ api }: { api: PluginAPI }) {
           : React.createElement(EmptyState),
       ),
     ),
+    // Sidebar resize divider (matches host ResizeDivider pattern)
+    React.createElement(ResizeDivider, {
+      collapsed: sidebarCollapsed,
+      onToggleCollapse: toggleSidebar,
+      onResize: (delta: number) => {
+        const current = useLoungeStore.getState().sidebarWidth;
+        setSidebarWidth(current + delta);
+      },
+    }),
     // Right content — selected agent view
     React.createElement('div', {
       className: 'flex-1 min-w-0 h-full',

--- a/plugins/lounge/src/main.ts
+++ b/plugins/lounge/src/main.ts
@@ -533,7 +533,7 @@ function CategorySection({ category, agents, allAgents, allCategories, projects,
   onEditCircle: (categoryId: string) => void;
   onDelete: (categoryId: string) => void;
   onMoveAgent: (agentId: string, targetCategoryId: string) => void;
-  onPlaceAgent: (agentId: string, targetCategoryId: string, beforeAgentId: string | null) => void;
+  onPlaceAgent: (agentId: string, targetCategoryId: string, beforeAgentId: string | null, currentAgentIds?: string[]) => void;
   onCreateCircle: (agentId?: string) => void;
   onReorderCategory: (fromId: string, toId: string) => void;
 }) {
@@ -578,7 +578,7 @@ function CategorySection({ category, agents, allAgents, allCategories, projects,
     const agentId = e.dataTransfer.getData('application/x-lounge-agent');
     if (agentId) {
       // Agent dropped on category header/whitespace — move to end of this circle
-      onPlaceAgent(agentId, category.id, null);
+      onPlaceAgent(agentId, category.id, null, agents.map((a) => a.id));
       return;
     }
     const fromCategoryId = e.dataTransfer.getData('application/x-lounge-category');
@@ -638,7 +638,7 @@ function CategorySection({ category, agents, allAgents, allCategories, projects,
           const rect = e.currentTarget.getBoundingClientRect();
           const isUpperHalf = e.clientY < rect.top + rect.height / 2;
           const beforeId = isUpperHalf ? agent.id : nextAgentId;
-          onPlaceAgent(draggedId, category.id, beforeId);
+          onPlaceAgent(draggedId, category.id, beforeId, agents.map((a) => a.id));
         },
       },
         React.createElement(AgentRow, {

--- a/plugins/lounge/src/main.ts
+++ b/plugins/lounge/src/main.ts
@@ -19,16 +19,6 @@ export function deactivate(): void {
 
 // ── Status helpers ─────────────────────────────────────────────────────
 
-function statusColor(status: AgentInfo['status']): string {
-  switch (status) {
-    case 'running': return 'bg-ctp-green';
-    case 'sleeping': return 'bg-ctp-yellow';
-    case 'error': return 'bg-ctp-red';
-    case 'creating': return 'bg-ctp-blue';
-    default: return 'bg-ctp-overlay0';
-  }
-}
-
 function statusLabel(status: AgentInfo['status']): string {
   switch (status) {
     case 'running': return 'Running';
@@ -41,12 +31,13 @@ function statusLabel(status: AgentInfo['status']): string {
 
 // ── Agent Row ──────────────────────────────────────────────────────────
 
-function AgentRow({ agent, displayName, isSelected, showTags, orchestrators, onClick, onContextMenu }: {
+function AgentRow({ agent, displayName, isSelected, showTags, orchestrators, api, onClick, onContextMenu }: {
   agent: AgentInfo;
   displayName: string;
   isSelected: boolean;
   showTags: boolean;
   orchestrators: PluginOrchestratorInfo[];
+  api: PluginAPI;
   onClick: () => void;
   onContextMenu: (e: React.MouseEvent) => void;
 }) {
@@ -54,6 +45,13 @@ function AgentRow({ agent, displayName, isSelected, showTags, orchestrators, onC
     e.dataTransfer.setData('application/x-lounge-agent', agent.id);
     e.dataTransfer.effectAllowed = 'move';
   }, [agent.id]);
+
+  const { AgentAvatar } = api.widgets;
+  const detailed = api.agents.getDetailedStatus(agent.id);
+  const statusText = detailed?.message ?? statusLabel(agent.status);
+  const statusTextColor = detailed?.state === 'needs_permission' ? 'text-ctp-peach'
+    : detailed?.state === 'tool_error' ? 'text-ctp-red'
+    : 'text-ctp-overlay0';
 
   return React.createElement('button', {
     key: agent.id,
@@ -69,9 +67,9 @@ function AgentRow({ agent, displayName, isSelected, showTags, orchestrators, onC
         : 'text-ctp-subtext1 hover:bg-surface-0 hover:text-ctp-text'
     }`,
   },
-    React.createElement('span', {
-      className: `w-2 h-2 rounded-full flex-shrink-0 ${statusColor(agent.status)}`,
-    }),
+    React.createElement('div', { className: 'flex-shrink-0' },
+      React.createElement(AgentAvatar, { agentId: agent.id, size: 'sm', showStatusRing: true }),
+    ),
     React.createElement('div', { className: 'min-w-0 flex-1' },
       React.createElement('span', { className: 'truncate block' }, displayName),
       showTags && React.createElement('div', {
@@ -101,10 +99,11 @@ function AgentRow({ agent, displayName, isSelected, showTags, orchestrators, onC
           'data-testid': 'lounge-tag-free',
         }, 'Free'),
       ),
+      React.createElement('span', {
+        className: `text-[10px] ${statusTextColor} block mt-0.5`,
+        'data-testid': `lounge-agent-status-${agent.id}`,
+      }, statusText),
     ),
-    agent.status === 'running' && React.createElement('span', {
-      className: 'text-[10px] text-ctp-green flex-shrink-0',
-    }, '●'),
   );
 }
 
@@ -686,6 +685,7 @@ function CategorySection({ category, agents, allAgents, allCategories, projects,
           isSelected: selectedAgentId === agent.id,
           showTags,
           orchestrators,
+          api,
           onClick: () => onSelectAgent(agent.id, agent.projectId),
           onContextMenu: (e: React.MouseEvent) => {
             e.preventDefault();

--- a/plugins/lounge/src/main.ts
+++ b/plugins/lounge/src/main.ts
@@ -1,0 +1,875 @@
+import React, { useEffect, useMemo, useState, useCallback, useRef } from 'react';
+import type { PluginContext, PluginAPI, PluginModule, AgentInfo } from '@clubhouse/plugin-types';
+import { createLoungeStore, groupAgentsByCategory, disambiguateAgentName, isDefaultCircle, isReservedCircleName, isDuplicateCircleName, getPersistedState, DEFAULT_CUSTOM_EMOJI } from './state';
+import type { LoungeCategory, LoungePersistedState } from './state';
+
+const useLoungeStore = createLoungeStore();
+
+const STORAGE_KEY = 'lounge-state';
+
+export function activate(ctx: PluginContext, _api: PluginAPI): void {
+  // No commands to register yet — reserved for future keybindings
+  void ctx;
+}
+
+export function deactivate(): void {
+  // subscriptions auto-disposed
+}
+
+// ── Status helpers ─────────────────────────────────────────────────────
+
+function statusColor(status: AgentInfo['status']): string {
+  switch (status) {
+    case 'running': return 'bg-ctp-green';
+    case 'sleeping': return 'bg-ctp-yellow';
+    case 'error': return 'bg-ctp-red';
+    case 'creating': return 'bg-ctp-blue';
+    default: return 'bg-ctp-overlay0';
+  }
+}
+
+function statusLabel(status: AgentInfo['status']): string {
+  switch (status) {
+    case 'running': return 'Running';
+    case 'sleeping': return 'Sleeping';
+    case 'error': return 'Error';
+    case 'creating': return 'Creating';
+    default: return status;
+  }
+}
+
+// ── Agent Row ──────────────────────────────────────────────────────────
+
+function AgentRow({ agent, displayName, isSelected, onClick, onContextMenu }: {
+  agent: AgentInfo;
+  displayName: string;
+  isSelected: boolean;
+  onClick: () => void;
+  onContextMenu: (e: React.MouseEvent) => void;
+}) {
+  const handleDragStart = useCallback((e: React.DragEvent) => {
+    e.dataTransfer.setData('application/x-lounge-agent', agent.id);
+    e.dataTransfer.effectAllowed = 'move';
+  }, [agent.id]);
+
+  return React.createElement('button', {
+    key: agent.id,
+    onClick,
+    onContextMenu,
+    draggable: true,
+    onDragStart: handleDragStart,
+    title: `${displayName} — ${statusLabel(agent.status)}`,
+    'data-testid': `lounge-agent-${agent.id}`,
+    className: `w-full text-left px-3 py-2 text-sm cursor-pointer transition-colors flex items-center gap-3 ${
+      isSelected
+        ? 'bg-surface-1 text-ctp-text'
+        : 'text-ctp-subtext1 hover:bg-surface-0 hover:text-ctp-text'
+    }`,
+  },
+    React.createElement('span', {
+      className: `w-2 h-2 rounded-full flex-shrink-0 ${statusColor(agent.status)}`,
+    }),
+    React.createElement('span', { className: 'truncate flex-1' }, displayName),
+    agent.status === 'running' && React.createElement('span', {
+      className: 'text-[10px] text-ctp-green flex-shrink-0',
+    }, '●'),
+  );
+}
+
+// ── Category Context Menu ───────────────────────────────────────────────
+
+function CategoryContextMenu({ position, categoryId, onRename, onDelete, onClose }: {
+  position: { x: number; y: number };
+  categoryId: string;
+  onRename: () => void;
+  onDelete: () => void;
+  onClose: () => void;
+}) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const isCustomCircle = categoryId.startsWith('circle:') && !isDefaultCircle(categoryId);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) onClose();
+    };
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [onClose]);
+
+  const style = useMemo(() => {
+    const menuWidth = 160;
+    const menuHeight = (isCustomCircle ? 64 : 32) + 8;
+    const x = Math.min(position.x, window.innerWidth - menuWidth - 8);
+    const y = Math.min(position.y, window.innerHeight - menuHeight - 8);
+    return { left: x, top: y };
+  }, [position, isCustomCircle]);
+
+  return React.createElement('div', {
+    ref: menuRef,
+    className: 'fixed z-50 min-w-[160px] py-1 rounded-lg shadow-xl border border-surface-1 bg-ctp-mantle',
+    style,
+    'data-testid': 'lounge-category-context-menu',
+  },
+    React.createElement('button', {
+      className: 'w-full flex items-center gap-2 px-3 py-1.5 text-xs text-ctp-subtext0 hover:bg-surface-1 hover:text-ctp-text transition-colors cursor-pointer',
+      onClick: (e: React.MouseEvent) => { e.stopPropagation(); onRename(); onClose(); },
+      'data-testid': 'lounge-ctx-rename',
+    },
+      React.createElement('svg', {
+        width: 12, height: 12, viewBox: '0 0 24 24', fill: 'none',
+        stroke: 'currentColor', strokeWidth: 2, strokeLinecap: 'round', strokeLinejoin: 'round',
+      },
+        React.createElement('path', { d: 'M17 3a2.83 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z' }),
+      ),
+      React.createElement('span', null, 'Rename'),
+    ),
+    // Delete option — only for custom circles (not project-derived)
+    isCustomCircle && React.createElement('button', {
+      className: 'w-full flex items-center gap-2 px-3 py-1.5 text-xs text-ctp-red hover:bg-surface-1 transition-colors cursor-pointer',
+      onClick: (e: React.MouseEvent) => { e.stopPropagation(); onDelete(); onClose(); },
+      'data-testid': 'lounge-ctx-delete',
+    },
+      React.createElement('svg', {
+        width: 12, height: 12, viewBox: '0 0 24 24', fill: 'none',
+        stroke: 'currentColor', strokeWidth: 2, strokeLinecap: 'round', strokeLinejoin: 'round',
+      },
+        React.createElement('polyline', { points: '3 6 5 6 21 6' }),
+        React.createElement('path', { d: 'M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2' }),
+      ),
+      React.createElement('span', null, 'Delete'),
+    ),
+  );
+}
+
+// ── Agent Context Menu ──────────────────────────────────────────────────
+
+function AgentContextMenu({ position, categories, currentCategoryId, onMoveTo, onCreateCircle, onClose }: {
+  position: { x: number; y: number };
+  categories: LoungeCategory[];
+  currentCategoryId: string;
+  onMoveTo: (categoryId: string) => void;
+  onCreateCircle: (agentId?: string) => void;
+  onClose: () => void;
+}) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [showSubmenu, setShowSubmenu] = useState(false);
+  const moveToRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) onClose();
+    };
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [onClose]);
+
+  const style = useMemo(() => {
+    const menuWidth = 160;
+    const menuHeight = 32 + 8;
+    const x = Math.min(position.x, window.innerWidth - menuWidth - 8);
+    const y = Math.min(position.y, window.innerHeight - menuHeight - 8);
+    return { left: x, top: y };
+  }, [position]);
+
+  // Position submenu relative to the "Move to" button
+  const submenuStyle = useMemo(() => {
+    if (!moveToRef.current) return { left: '100%', top: 0 };
+    const rect = moveToRef.current.getBoundingClientRect();
+    const submenuWidth = 180;
+    const submenuHeight = categories.length * 28 + 8;
+    // Flip left if not enough space on the right
+    const goLeft = rect.right + submenuWidth > window.innerWidth - 8;
+    const x = goLeft ? -submenuWidth : rect.width;
+    const y = Math.min(0, window.innerHeight - rect.top - submenuHeight - 8);
+    return { left: x, top: y };
+  }, [showSubmenu, categories.length]);
+
+  return React.createElement('div', {
+    ref: menuRef,
+    className: 'fixed z-50 min-w-[160px] py-1 rounded-lg shadow-xl border border-surface-1 bg-ctp-mantle',
+    style,
+    'data-testid': 'lounge-agent-context-menu',
+  },
+    // "Move to" with submenu
+    React.createElement('div', { className: 'relative' },
+      React.createElement('button', {
+        ref: moveToRef,
+        className: 'w-full flex items-center gap-2 px-3 py-1.5 text-xs text-ctp-subtext0 hover:bg-surface-1 hover:text-ctp-text transition-colors cursor-pointer',
+        onMouseEnter: () => setShowSubmenu(true),
+        onMouseLeave: () => setShowSubmenu(false),
+        onClick: () => setShowSubmenu((v) => !v),
+        'data-testid': 'lounge-ctx-move-to',
+      },
+        // Move icon
+        React.createElement('svg', {
+          width: 12, height: 12, viewBox: '0 0 24 24', fill: 'none',
+          stroke: 'currentColor', strokeWidth: 2, strokeLinecap: 'round', strokeLinejoin: 'round',
+        },
+          React.createElement('path', { d: 'M15 3h6v6' }),
+          React.createElement('path', { d: 'M10 14L21 3' }),
+          React.createElement('path', { d: 'M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6' }),
+        ),
+        React.createElement('span', { className: 'flex-1 text-left' }, 'Move to'),
+        // Chevron right
+        React.createElement('svg', {
+          width: 10, height: 10, viewBox: '0 0 24 24', fill: 'none',
+          stroke: 'currentColor', strokeWidth: 2, strokeLinecap: 'round', strokeLinejoin: 'round',
+        },
+          React.createElement('polyline', { points: '9 18 15 12 9 6' }),
+        ),
+      ),
+      // Submenu
+      showSubmenu && React.createElement('div', {
+        className: 'absolute z-50 min-w-[180px] py-1 rounded-lg shadow-xl border border-surface-1 bg-ctp-mantle',
+        style: submenuStyle,
+        onMouseEnter: () => setShowSubmenu(true),
+        onMouseLeave: () => setShowSubmenu(false),
+        'data-testid': 'lounge-move-to-submenu',
+      },
+        categories.map((cat) =>
+          React.createElement('button', {
+            key: cat.id,
+            className: `w-full text-left px-3 py-1.5 text-xs transition-colors cursor-pointer ${
+              cat.id === currentCategoryId
+                ? 'text-ctp-overlay0 cursor-default'
+                : 'text-ctp-subtext0 hover:bg-surface-1 hover:text-ctp-text'
+            }`,
+            disabled: cat.id === currentCategoryId,
+            onClick: (e: React.MouseEvent) => {
+              e.stopPropagation();
+              if (cat.id !== currentCategoryId) {
+                onMoveTo(cat.id);
+                onClose();
+              }
+            },
+            'data-testid': `lounge-move-to-${cat.id}`,
+          },
+            React.createElement('span', null, cat.label),
+            cat.id === currentCategoryId && React.createElement('span', {
+              className: 'ml-2 text-[10px] text-ctp-overlay0',
+            }, '(current)'),
+          ),
+        ),
+        // Divider + Create new
+        React.createElement('div', { className: 'mx-2 my-1 border-t border-surface-1' }),
+        React.createElement('button', {
+          className: 'w-full flex items-center gap-2 px-3 py-1.5 text-xs text-ctp-accent hover:bg-surface-1 transition-colors cursor-pointer',
+          onClick: (e: React.MouseEvent) => {
+            e.stopPropagation();
+            onCreateCircle();
+            onClose();
+          },
+          'data-testid': 'lounge-move-to-create-new',
+        },
+          React.createElement('svg', {
+            width: 12, height: 12, viewBox: '0 0 24 24', fill: 'none',
+            stroke: 'currentColor', strokeWidth: 2, strokeLinecap: 'round', strokeLinejoin: 'round',
+          },
+            React.createElement('line', { x1: '12', y1: '5', x2: '12', y2: '19' }),
+            React.createElement('line', { x1: '5', y1: '12', x2: '19', y2: '12' }),
+          ),
+          React.createElement('span', null, 'Create new'),
+        ),
+      ),
+    ),
+  );
+}
+
+// ── Category Section ───────────────────────────────────────────────────
+
+const CHEVRON_RIGHT = React.createElement('svg', {
+  width: 12, height: 12, viewBox: '0 0 24 24', fill: 'none',
+  stroke: 'currentColor', strokeWidth: 2, strokeLinecap: 'round', strokeLinejoin: 'round',
+}, React.createElement('polyline', { points: '9 18 15 12 9 6' }));
+
+const CHEVRON_DOWN = React.createElement('svg', {
+  width: 12, height: 12, viewBox: '0 0 24 24', fill: 'none',
+  stroke: 'currentColor', strokeWidth: 2, strokeLinecap: 'round', strokeLinejoin: 'round',
+}, React.createElement('polyline', { points: '6 9 12 15 18 9' }));
+
+// ── Emoji Picker ──────────────────────────────────────────────────────
+
+const EMOJI_OPTIONS = [
+  '⭐', '💬', '🔥', '🚀', '💡', '🎯', '🏠', '📁',
+  '🛠️', '🧪', '📋', '🎨', '🔒', '🌐', '📊', '🤖',
+  '💎', '🎵', '📸', '🏆', '❤️', '⚡', '🌟', '🎮',
+];
+
+function EmojiPicker({ currentEmoji, onSelect, onClose }: {
+  currentEmoji: string;
+  onSelect: (emoji: string) => void;
+  onClose: () => void;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose();
+    };
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [onClose]);
+
+  return React.createElement('div', {
+    ref,
+    className: 'ml-8 mr-3 mb-1 p-2 rounded-lg bg-ctp-mantle border border-surface-1 shadow-lg grid grid-cols-8 gap-1',
+    'data-testid': 'lounge-emoji-picker',
+  },
+    ...EMOJI_OPTIONS.map((emoji) =>
+      React.createElement('button', {
+        key: emoji,
+        onClick: () => onSelect(emoji),
+        className: `w-7 h-7 flex items-center justify-center rounded text-sm cursor-pointer transition-colors ${
+          emoji === currentEmoji ? 'bg-surface-1 ring-1 ring-ctp-accent' : 'hover:bg-surface-0'
+        }`,
+        'data-testid': `lounge-emoji-option-${emoji}`,
+      }, emoji),
+    ),
+  );
+}
+
+// ── Create Circle Dialog ──────────────────────────────────────────────
+
+function CircleDialog({ mode, onConfirm, onCancel, existingCategories, initialName, initialEmoji, editCategoryId }: {
+  mode: 'create' | 'edit';
+  onConfirm: (name: string, emoji?: string) => void;
+  onCancel: () => void;
+  existingCategories: LoungeCategory[];
+  initialName?: string;
+  initialEmoji?: string;
+  editCategoryId?: string;
+}) {
+  const [value, setValue] = useState(initialName ?? '');
+  const [emoji, setEmoji] = useState(initialEmoji ?? DEFAULT_CUSTOM_EMOJI);
+  const [showEmojis, setShowEmojis] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    if (mode === 'edit') inputRef.current?.select();
+  }, [mode]);
+
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel();
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [onCancel]);
+
+  const handleSubmit = useCallback(() => {
+    const trimmed = value.trim();
+    if (trimmed && !isReservedCircleName(trimmed) && !isDuplicateCircleName(trimmed, existingCategories, editCategoryId)) {
+      onConfirm(trimmed, emoji);
+    }
+  }, [value, emoji, onConfirm, existingCategories, editCategoryId]);
+
+  const trimmed = value.trim();
+  const isReserved = trimmed.length > 0 && isReservedCircleName(trimmed);
+  const isDuplicate = trimmed.length > 0 && !isReserved && isDuplicateCircleName(trimmed, existingCategories, editCategoryId);
+  const isValid = trimmed.length > 0 && !isReserved && !isDuplicate;
+  const isCreate = mode === 'create';
+
+  return React.createElement('div', {
+    className: 'fixed inset-0 z-50 flex items-center justify-center bg-black/50',
+    onClick: onCancel,
+  },
+    React.createElement('div', {
+      className: 'bg-ctp-mantle border border-surface-1 rounded-xl p-4 w-72 shadow-2xl',
+      onClick: (e: React.MouseEvent) => e.stopPropagation(),
+    },
+      React.createElement('h3', {
+        className: 'text-sm font-semibold text-ctp-text mb-3',
+      }, isCreate ? 'Create a new circle' : 'Rename circle'),
+      // Emoji + input row
+      React.createElement('div', { className: 'flex items-center gap-2' },
+        // Emoji button
+        React.createElement('button', {
+          onClick: () => setShowEmojis(!showEmojis),
+          className: 'w-8 h-8 flex-shrink-0 flex items-center justify-center rounded-lg bg-ctp-base border border-surface-1 text-base hover:bg-surface-0 transition-colors cursor-pointer',
+          title: 'Choose icon',
+          'data-testid': 'lounge-circle-dialog-emoji-btn',
+        }, emoji),
+        React.createElement('input', {
+          ref: inputRef,
+          type: 'text',
+          value,
+          placeholder: 'Enter circle name',
+          className: 'flex-1 min-w-0 px-3 py-1.5 rounded-lg bg-ctp-base border border-surface-1 text-xs text-ctp-text placeholder-ctp-overlay0 outline-none focus:ring-1 focus:ring-ctp-accent',
+          onChange: (e: React.ChangeEvent<HTMLInputElement>) => setValue(e.target.value),
+          onKeyDown: (e: React.KeyboardEvent) => {
+            if (e.key === 'Enter' && isValid) handleSubmit();
+            if (e.key === 'Escape') onCancel();
+          },
+          'data-testid': 'lounge-circle-dialog-input',
+        }),
+      ),
+      // Inline emoji picker
+      showEmojis && React.createElement('div', {
+        className: 'mt-2 p-2 rounded-lg bg-ctp-base border border-surface-1 grid grid-cols-8 gap-1',
+        'data-testid': 'lounge-circle-dialog-emoji-picker',
+      },
+        ...EMOJI_OPTIONS.map((e) =>
+          React.createElement('button', {
+            key: e,
+            onClick: () => { setEmoji(e); setShowEmojis(false); },
+            className: `w-7 h-7 flex items-center justify-center rounded text-sm cursor-pointer transition-colors ${
+              e === emoji ? 'bg-surface-1 ring-1 ring-ctp-accent' : 'hover:bg-surface-0'
+            }`,
+          }, e),
+        ),
+      ),
+      isReserved && React.createElement('p', {
+        className: 'text-[10px] text-ctp-red mt-1',
+      }, 'This name is reserved'),
+      isDuplicate && React.createElement('p', {
+        className: 'text-[10px] text-ctp-red mt-1',
+      }, 'A circle with this name already exists'),
+      React.createElement('div', {
+        className: 'flex justify-end gap-2 mt-3',
+      },
+        React.createElement('button', {
+          onClick: onCancel,
+          className: 'px-3 py-1 rounded-md text-xs text-ctp-subtext0 hover:text-ctp-text hover:bg-surface-0 transition-colors cursor-pointer',
+          'data-testid': 'lounge-circle-dialog-cancel',
+        }, 'Cancel'),
+        React.createElement('button', {
+          onClick: handleSubmit,
+          disabled: !isValid,
+          className: `px-3 py-1 rounded-md text-xs transition-colors cursor-pointer ${
+            isValid
+              ? 'bg-ctp-accent text-ctp-base hover:opacity-90'
+              : 'bg-surface-1 text-ctp-overlay0 cursor-not-allowed'
+          }`,
+          'data-testid': 'lounge-circle-dialog-confirm',
+        }, isCreate ? 'Create' : 'Save'),
+      ),
+    ),
+  );
+}
+
+function CategorySection({ category, agents, allAgents, allCategories, projects, isCollapsed, selectedAgentId, onToggle, onSelectAgent, onEditCircle, onDelete, onMoveAgent, onCreateCircle, onReorderCategory }: {
+  category: LoungeCategory;
+  agents: AgentInfo[];
+  allAgents: AgentInfo[];
+  allCategories: LoungeCategory[];
+  projects: { id: string; name: string; path: string }[];
+  isCollapsed: boolean;
+  selectedAgentId: string | null;
+  onToggle: () => void;
+  onSelectAgent: (agentId: string, projectId: string) => void;
+  onEditCircle: (categoryId: string) => void;
+  onDelete: (categoryId: string) => void;
+  onMoveAgent: (agentId: string, targetCategoryId: string) => void;
+  onCreateCircle: (agentId?: string) => void;
+  onReorderCategory: (fromId: string, toId: string) => void;
+}) {
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
+  const [agentContextMenu, setAgentContextMenu] = useState<{ agentId: string; x: number; y: number } | null>(null);
+  const [dragOver, setDragOver] = useState(false);
+
+  const handleContextMenu = useCallback((e: React.MouseEvent) => {
+    if (isDefaultCircle(category.id)) return;
+    e.preventDefault();
+    setContextMenu({ x: e.clientX, y: e.clientY });
+  }, [category.id]);
+
+  // ── Drag-and-drop handlers ──
+
+  const isGeneralCircle = isDefaultCircle(category.id);
+
+  const handleDragStart = useCallback((e: React.DragEvent) => {
+    if (isGeneralCircle) { e.preventDefault(); return; }
+    e.dataTransfer.setData('application/x-lounge-category', category.id);
+    e.dataTransfer.effectAllowed = 'move';
+  }, [category.id, isGeneralCircle]);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    const hasAgent = e.dataTransfer.types.includes('application/x-lounge-agent');
+    const hasCategory = e.dataTransfer.types.includes('application/x-lounge-category');
+    if (!hasAgent && !hasCategory) return;
+    // Cannot drop a category onto General
+    if (hasCategory && isGeneralCircle) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    setDragOver(true);
+  }, [isGeneralCircle]);
+
+  const handleDragLeave = useCallback(() => {
+    setDragOver(false);
+  }, []);
+
+  const handleDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setDragOver(false);
+    const agentId = e.dataTransfer.getData('application/x-lounge-agent');
+    if (agentId) {
+      onMoveAgent(agentId, category.id);
+      return;
+    }
+    const fromCategoryId = e.dataTransfer.getData('application/x-lounge-category');
+    if (fromCategoryId && fromCategoryId !== category.id && !isGeneralCircle) {
+      onReorderCategory(fromCategoryId, category.id);
+    }
+  }, [category.id, onMoveAgent, onReorderCategory, isGeneralCircle]);
+
+  return React.createElement('div', {
+    'data-testid': `lounge-category-${category.id}`,
+    onDragOver: handleDragOver,
+    onDragLeave: handleDragLeave,
+    onDrop: handleDrop,
+  },
+    // Category header
+    React.createElement('button', {
+      onClick: onToggle,
+      onContextMenu: handleContextMenu,
+      draggable: !isGeneralCircle,
+      onDragStart: handleDragStart,
+      className: `w-full flex items-center gap-2 px-3 py-2 text-xs font-semibold text-ctp-subtext0 uppercase tracking-wider hover:bg-surface-0 cursor-pointer transition-colors ${
+        dragOver ? 'bg-surface-1 ring-1 ring-ctp-accent ring-inset' : ''
+      }`,
+      'data-testid': `lounge-category-toggle-${category.id}`,
+    },
+      isCollapsed ? CHEVRON_RIGHT : CHEVRON_DOWN,
+      React.createElement('span', { className: 'text-sm flex-shrink-0' }, category.emoji || '📁'),
+      React.createElement('span', { className: 'flex-1 text-left truncate' }, category.label),
+      React.createElement('span', { className: 'text-[10px] text-ctp-overlay0 tabular-nums' }, String(agents.length)),
+    ),
+    // Context menu
+    contextMenu && React.createElement(CategoryContextMenu, {
+      position: contextMenu,
+      categoryId: category.id,
+      onRename: () => { setContextMenu(null); onEditCircle(category.id); },
+      onDelete: () => onDelete(category.id),
+      onClose: () => setContextMenu(null),
+    }),
+    // Agent rows (hidden when collapsed)
+    !isCollapsed && agents.length > 0 && agents.map((agent) => {
+      const displayName = disambiguateAgentName(agent, allAgents, projects);
+      return React.createElement(AgentRow, {
+        key: agent.id,
+        agent,
+        displayName,
+        isSelected: selectedAgentId === agent.id,
+        onClick: () => onSelectAgent(agent.id, agent.projectId),
+        onContextMenu: (e: React.MouseEvent) => {
+          e.preventDefault();
+          setAgentContextMenu({ agentId: agent.id, x: e.clientX, y: e.clientY });
+        },
+      });
+    }),
+    // Empty custom circle hint
+    !isCollapsed && agents.length === 0 && React.createElement('div', {
+      className: 'px-8 py-2 text-[11px] text-ctp-overlay0 italic',
+    }, 'Move agents here via right-click'),
+    // Agent context menu
+    agentContextMenu && React.createElement(AgentContextMenu, {
+      position: agentContextMenu,
+      categories: allCategories,
+      currentCategoryId: category.id,
+      onMoveTo: (targetCategoryId: string) => onMoveAgent(agentContextMenu.agentId, targetCategoryId),
+      onCreateCircle: () => onCreateCircle(agentContextMenu.agentId),
+      onClose: () => setAgentContextMenu(null),
+    }),
+  );
+}
+
+// ── Empty State ────────────────────────────────────────────────────────
+
+function EmptyState() {
+  return React.createElement('div', {
+    className: 'flex items-center justify-center h-full text-center px-6',
+  },
+    React.createElement('div', null,
+      React.createElement('p', { className: 'text-ctp-subtext0 text-sm mb-1' }, 'No agents yet'),
+      React.createElement('p', { className: 'text-ctp-overlay0 text-xs' }, 'Agents will appear here grouped by project.'),
+    ),
+  );
+}
+
+// ── Agent Content ──────────────────────────────────────────────────────
+
+function AgentContent({ api, agentId }: { api: PluginAPI; agentId: string }) {
+  const agents = api.agents.list();
+  const agent = agents.find((a) => a.id === agentId);
+
+  if (!agent) {
+    return React.createElement('div', {
+      className: 'flex items-center justify-center h-full text-ctp-subtext0 text-sm',
+    }, 'Agent not found');
+  }
+
+  const { AgentTerminal, SleepingAgent } = api.widgets;
+
+  if (agent.status === 'sleeping' || agent.status === 'error') {
+    return React.createElement(SleepingAgent, { agentId: agent.id });
+  }
+
+  return React.createElement(AgentTerminal, { agentId: agent.id, focused: true });
+}
+
+// ── No Selection Placeholder ───────────────────────────────────────────
+
+function NoSelection() {
+  return React.createElement('div', {
+    className: 'flex items-center justify-center h-full text-center px-6',
+    'data-testid': 'lounge-no-selection',
+  },
+    React.createElement('div', null,
+      React.createElement('p', { className: 'text-ctp-subtext0 text-sm mb-1' }, 'Select an agent'),
+      React.createElement('p', { className: 'text-ctp-overlay0 text-xs' }, 'Click an agent from the list to view it here.'),
+    ),
+  );
+}
+
+// ── Main Panel ─────────────────────────────────────────────────────────
+
+export function MainPanel({ api }: { api: PluginAPI }) {
+  const categories = useLoungeStore((s) => s.categories);
+  const collapsed = useLoungeStore((s) => s.collapsed);
+  const selectedAgentId = useLoungeStore((s) => s.selectedAgentId);
+  const deriveCategories = useLoungeStore((s) => s.deriveCategories);
+  const toggleCollapsed = useLoungeStore((s) => s.toggleCollapsed);
+  const selectAgent = useLoungeStore((s) => s.selectAgent);
+  const renameCategory = useLoungeStore((s) => s.renameCategory);
+  const moveAgent = useLoungeStore((s) => s.moveAgent);
+  const agentCategoryOverrides = useLoungeStore((s) => s.agentCategoryOverrides);
+  const addCircle = useLoungeStore((s) => s.addCircle);
+  const deleteCircle = useLoungeStore((s) => s.deleteCircle);
+  const reorderCategory = useLoungeStore((s) => s.reorderCategory);
+  const setCategoryEmoji = useLoungeStore((s) => s.setCategoryEmoji);
+  const loadPersistedState = useLoungeStore((s) => s.loadPersistedState);
+
+  // Load persisted state on mount
+  const [loaded, setLoaded] = useState(false);
+  useEffect(() => {
+    api.storage.global.read(STORAGE_KEY).then((data) => {
+      if (data) loadPersistedState(data as LoungePersistedState);
+      else useLoungeStore.setState({ hydrated: true });
+      setLoaded(true);
+    }).catch(() => {
+      useLoungeStore.setState({ hydrated: true });
+      setLoaded(true);
+    });
+  }, [api, loadPersistedState]);
+
+  // Debounced auto-save (500ms after any persistable state change)
+  const renamedLabels = useLoungeStore((s) => s.renamedLabels);
+  const customCircles = useLoungeStore((s) => s.customCircles);
+  const nextCircleId = useLoungeStore((s) => s.nextCircleId);
+  const categoryOrder = useLoungeStore((s) => s.categoryOrder);
+  const categoryEmojis = useLoungeStore((s) => s.categoryEmojis);
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!loaded) return;
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = setTimeout(() => {
+      const state = useLoungeStore.getState();
+      api.storage.global.write(STORAGE_KEY, getPersistedState(state)).catch(() => {});
+    }, 500);
+    return () => {
+      // Flush pending save synchronously on unmount to prevent data loss
+      if (saveTimerRef.current) {
+        clearTimeout(saveTimerRef.current);
+        const state = useLoungeStore.getState();
+        api.storage.global.write(STORAGE_KEY, getPersistedState(state)).catch(() => {});
+      }
+    };
+  }, [api, loaded, renamedLabels, agentCategoryOverrides, customCircles, nextCircleId, categoryOrder, categoryEmojis, collapsed]);
+
+  // Force re-render when agents change
+  const [agentTick, setAgentTick] = useState(0);
+  useEffect(() => {
+    const sub = api.agents.onAnyChange(() => setAgentTick((n) => n + 1));
+    return () => sub.dispose();
+  }, [api]);
+
+  // Derive categories from projects
+  const projects = useMemo(() => api.projects.list(), [api, agentTick]);
+  useEffect(() => {
+    deriveCategories(projects);
+  }, [projects, deriveCategories]);
+
+  // Get all agents across projects
+  const agents = useMemo(() => api.agents.list(), [api, agentTick]);
+
+  // Group agents by category (respecting overrides)
+  const grouped = useMemo(
+    () => groupAgentsByCategory(agents, categories, agentCategoryOverrides),
+    [agents, categories, agentCategoryOverrides],
+  );
+
+  const handleSelectAgent = useCallback((agentId: string, projectId: string) => {
+    selectAgent(agentId, projectId);
+  }, [selectAgent]);
+
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const [pendingMoveAgentId, setPendingMoveAgentId] = useState<string | null>(null);
+  const [editingCircle, setEditingCircle] = useState<{ id: string; label: string; emoji?: string } | null>(null);
+
+  const handleCreateCircle = useCallback((agentId?: string) => {
+    setPendingMoveAgentId(agentId ?? null);
+    setShowCreateDialog(true);
+  }, []);
+
+  const handleConfirmCreate = useCallback((name: string, emoji?: string) => {
+    const newId = addCircle(name);
+    if (newId) {
+      if (emoji && emoji !== DEFAULT_CUSTOM_EMOJI) {
+        setCategoryEmoji(newId, emoji);
+      }
+      if (pendingMoveAgentId) {
+        moveAgent(pendingMoveAgentId, newId);
+      }
+    }
+    setShowCreateDialog(false);
+    setPendingMoveAgentId(null);
+  }, [addCircle, moveAgent, setCategoryEmoji, pendingMoveAgentId]);
+
+  const handleEditCircle = useCallback((categoryId: string) => {
+    const cat = categories.find((c) => c.id === categoryId);
+    if (cat) {
+      setEditingCircle({ id: cat.id, label: cat.label, emoji: cat.emoji });
+    }
+  }, [categories]);
+
+  const handleConfirmEdit = useCallback((name: string, emoji?: string) => {
+    if (editingCircle) {
+      if (name !== editingCircle.label) {
+        renameCategory(editingCircle.id, name);
+      }
+      if (emoji) {
+        setCategoryEmoji(editingCircle.id, emoji);
+      }
+    }
+    setEditingCircle(null);
+  }, [editingCircle, renameCategory, setCategoryEmoji]);
+
+  // Clear selection when agent disappears
+  useEffect(() => {
+    if (selectedAgentId && !agents.find((a) => a.id === selectedAgentId)) {
+      selectAgent(null);
+    }
+  }, [agents, selectedAgentId, selectAgent]);
+
+  // Auto-delete empty custom circles (not project-derived, not General)
+  // Only runs after hydration + agents loaded to avoid premature cleanup
+  useEffect(() => {
+    if (!loaded || agents.length === 0) return;
+    for (const cat of categories) {
+      if (cat.projectId || isDefaultCircle(cat.id)) continue;
+      const catAgents = grouped.get(cat.id) ?? [];
+      if (catAgents.length === 0) {
+        deleteCircle(cat.id);
+      }
+    }
+  }, [grouped, categories, deleteCircle, loaded, agents.length]);
+
+  const hasAgents = agents.length > 0;
+
+  // Hide empty project categories (no agents assigned)
+  const visibleCategories = categories.filter((cat) => {
+    if (cat.projectId) {
+      const catAgents = grouped.get(cat.id) ?? [];
+      return catAgents.length > 0;
+    }
+    return true;
+  });
+
+  return React.createElement('div', {
+    className: 'flex h-full w-full bg-ctp-base',
+    'data-testid': 'lounge-main-panel',
+  },
+    // Left sidebar — agent list
+    React.createElement('div', {
+      className: 'w-64 flex-shrink-0 flex flex-col bg-ctp-mantle border-r border-surface-0 h-full min-h-0',
+    },
+      // Header
+      React.createElement('div', {
+        className: 'px-3 py-3 border-b border-surface-0',
+      },
+        React.createElement('h2', {
+          className: 'text-xs font-semibold text-ctp-subtext0 uppercase tracking-wider',
+        }, 'Lounge'),
+      ),
+      // Scrollable category list
+      React.createElement('div', {
+        className: 'flex-1 overflow-y-auto py-1',
+        'data-testid': 'lounge-category-list',
+      },
+        hasAgents || categories.some((c) => !c.projectId)
+          ? visibleCategories.map((cat) => {
+              const catAgents = grouped.get(cat.id) ?? [];
+              return React.createElement(CategorySection, {
+                key: cat.id,
+                category: cat,
+                agents: catAgents,
+                allAgents: agents,
+                allCategories: categories,
+                projects,
+                isCollapsed: collapsed.has(cat.id),
+                selectedAgentId,
+                onToggle: () => toggleCollapsed(cat.id),
+                onSelectAgent: handleSelectAgent,
+                onEditCircle: handleEditCircle,
+                onDelete: deleteCircle,
+                onMoveAgent: moveAgent,
+                onCreateCircle: handleCreateCircle,
+                onReorderCategory: reorderCategory,
+              });
+            })
+          : React.createElement(EmptyState),
+      ),
+    ),
+    // Right content — selected agent view
+    React.createElement('div', {
+      className: 'flex-1 min-w-0 h-full',
+    },
+      selectedAgentId
+        ? React.createElement(AgentContent, { api, agentId: selectedAgentId })
+        : React.createElement(NoSelection),
+    ),
+    // Circle dialog (create or edit mode)
+    showCreateDialog && React.createElement(CircleDialog, {
+      mode: 'create',
+      onConfirm: handleConfirmCreate,
+      onCancel: () => setShowCreateDialog(false),
+      existingCategories: categories,
+    }),
+    editingCircle && React.createElement(CircleDialog, {
+      mode: 'edit',
+      onConfirm: handleConfirmEdit,
+      onCancel: () => setEditingCircle(null),
+      existingCategories: categories,
+      initialName: editingCircle.label,
+      initialEmoji: editingCircle.emoji,
+      editCategoryId: editingCircle.id,
+    }),
+  );
+}
+
+// Compile-time type assertion
+const _: PluginModule = { activate, deactivate, MainPanel };
+void _;

--- a/plugins/lounge/src/main.ts
+++ b/plugins/lounge/src/main.ts
@@ -333,7 +333,8 @@ function EmojiPicker({ currentEmoji, onSelect, onClose }: {
 
   return React.createElement('div', {
     ref,
-    className: 'ml-8 mr-3 mb-1 p-2 rounded-lg bg-ctp-mantle border border-surface-1 shadow-lg grid grid-cols-8 gap-1',
+    className: 'ml-8 mr-3 mb-1 p-2 rounded-lg bg-ctp-mantle border border-surface-1 shadow-lg',
+    style: { display: 'grid', gridTemplateColumns: 'repeat(8, 1fr)', gap: '4px' },
     'data-testid': 'lounge-emoji-picker',
   },
     ...EMOJI_OPTIONS.map((emoji) =>
@@ -427,7 +428,8 @@ function CircleDialog({ mode, onConfirm, onCancel, existingCategories, initialNa
       ),
       // Inline emoji picker
       showEmojis && React.createElement('div', {
-        className: 'mt-2 p-2 rounded-lg bg-ctp-base border border-surface-1 grid grid-cols-8 gap-1',
+        className: 'mt-2 p-2 rounded-lg bg-ctp-base border border-surface-1',
+        style: { display: 'grid', gridTemplateColumns: 'repeat(8, 1fr)', gap: '4px' },
         'data-testid': 'lounge-circle-dialog-emoji-picker',
       },
         ...EMOJI_OPTIONS.map((e) =>

--- a/plugins/lounge/src/manifest.test.ts
+++ b/plugins/lounge/src/manifest.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const manifest = JSON.parse(readFileSync(join(__dirname, '..', 'manifest.json'), 'utf-8'));
+
+describe('lounge manifest', () => {
+  it('is valid JSON with required fields', () => {
+    expect(manifest.id).toBe('lounge');
+    expect(manifest.name).toBe('Lounge');
+    expect(manifest.version).toBeDefined();
+    expect(manifest.engine.api).toBeDefined();
+  });
+
+  it('has id "lounge"', () => {
+    expect(manifest.id).toBe('lounge');
+  });
+
+  it('has scope "app"', () => {
+    expect(manifest.scope).toBe('app');
+  });
+
+  it('targets engine.api 0.8', () => {
+    expect(manifest.engine.api).toBe(0.8);
+  });
+
+  it('declares required permissions', () => {
+    expect(manifest.permissions).toEqual(
+      expect.arrayContaining([
+        'agents', 'projects', 'navigation', 'widgets', 'commands', 'storage',
+      ]),
+    );
+    expect(manifest.permissions).toHaveLength(6);
+  });
+
+  it('contributes a railItem with label and top position', () => {
+    expect(manifest.contributes?.railItem).toBeDefined();
+    expect(manifest.contributes.railItem.label).toBe('Lounge');
+    expect(manifest.contributes.railItem.position).toBe('top');
+  });
+
+  it('has a rail icon (SVG string)', () => {
+    expect(manifest.contributes.railItem.icon).toContain('<svg');
+  });
+
+  it('does not contribute a tab (app-scope rail only)', () => {
+    expect(manifest.contributes?.tab).toBeUndefined();
+  });
+
+  it('contributes global storage scope', () => {
+    expect(manifest.contributes?.storage).toBeDefined();
+    expect(manifest.contributes.storage.scope).toBe('global');
+  });
+
+  it('contributes help topics', () => {
+    expect(manifest.contributes?.help).toBeDefined();
+    expect(manifest.contributes.help.topics).toBeDefined();
+    expect(manifest.contributes.help.topics.length).toBeGreaterThan(0);
+  });
+});

--- a/plugins/lounge/src/state.test.ts
+++ b/plugins/lounge/src/state.test.ts
@@ -608,6 +608,93 @@ describe('hydration guard', () => {
   });
 });
 
+describe('circle persistence race condition', () => {
+  it('deriveCategories before loadPersistedState loses overrides (documents the bug)', () => {
+    const store = createLoungeStore();
+    const projects = [makeProject({ id: 'p1', name: 'P1' })];
+
+    // Simulate the race: derive runs before persisted state is loaded
+    store.getState().deriveCategories(projects);
+
+    // At this point, agentCategoryOverrides is empty — agents in default circles
+    expect(store.getState().agentCategoryOverrides).toEqual({});
+
+    // Now load persisted state (too late for the first derive)
+    store.getState().loadPersistedState({
+      agentCategoryOverrides: { 'a1': 'circle:1' },
+      customCircles: [{ id: 'circle:1', label: 'Favorites', emoji: '⭐' }],
+      nextCircleId: 2,
+      categoryOrder: ['circle:1', 'project:p1', 'circle:general'],
+      categoryEmojis: {},
+      renamedLabels: {},
+      collapsed: [],
+    });
+
+    // Overrides are loaded but categories haven't been re-derived yet
+    expect(store.getState().agentCategoryOverrides['a1']).toBe('circle:1');
+    // Custom circle is in state but not in categories until next derive
+    expect(store.getState().customCircles).toHaveLength(1);
+  });
+
+  it('loadPersistedState then deriveCategories preserves overrides (the fix)', () => {
+    const store = createLoungeStore();
+    const projects = [makeProject({ id: 'p1', name: 'P1' })];
+
+    // Fix: load persisted state FIRST
+    store.getState().loadPersistedState({
+      agentCategoryOverrides: { 'a1': 'circle:1' },
+      customCircles: [{ id: 'circle:1', label: 'Favorites', emoji: '⭐' }],
+      nextCircleId: 2,
+      categoryOrder: ['circle:1', 'project:p1', 'circle:general'],
+      categoryEmojis: {},
+      renamedLabels: {},
+      collapsed: [],
+    });
+
+    expect(store.getState().hydrated).toBe(true);
+
+    // Now derive — custom circles and overrides are already in state
+    store.getState().deriveCategories(projects);
+
+    const state = store.getState();
+    // Override survives
+    expect(state.agentCategoryOverrides['a1']).toBe('circle:1');
+    // Custom circle appears in categories
+    expect(state.categories.find((c: LoungeCategory) => c.id === 'circle:1')?.label).toBe('Favorites');
+    // Project category also present
+    expect(state.categories.find((c: LoungeCategory) => c.id === 'project:p1')).toBeDefined();
+    // Order is preserved
+    expect(state.categoryOrder).toEqual(['circle:1', 'project:p1', 'circle:general']);
+  });
+
+  it('groupAgentsByCategory respects overrides when loaded before derive', () => {
+    const store = createLoungeStore();
+
+    store.getState().loadPersistedState({
+      agentCategoryOverrides: { 'a1': 'circle:1' },
+      customCircles: [{ id: 'circle:1', label: 'Favorites', emoji: '⭐' }],
+      nextCircleId: 2,
+      categoryOrder: [],
+      categoryEmojis: {},
+      renamedLabels: {},
+      collapsed: [],
+    });
+
+    store.getState().deriveCategories([makeProject({ id: 'p1', name: 'P1' })]);
+
+    const agents = [makeAgent({ id: 'a1', projectId: 'p1', name: 'Agent One' })];
+    const { categories, agentCategoryOverrides } = store.getState();
+    const grouped = groupAgentsByCategory(agents, categories, agentCategoryOverrides);
+
+    // Agent should be in Favorites circle, not project circle
+    expect(grouped.get('circle:1')).toHaveLength(1);
+    expect(grouped.get('circle:1')![0].id).toBe('a1');
+
+    // Project circle should be empty
+    expect(grouped.get('project:p1') ?? []).toHaveLength(0);
+  });
+});
+
 describe('General project name collision', () => {
   it('disambiguates project named General', () => {
     const store = createHydratedStore();

--- a/plugins/lounge/src/state.test.ts
+++ b/plugins/lounge/src/state.test.ts
@@ -921,6 +921,34 @@ describe('placeAgent', () => {
     store.getState().placeAgent('a1', 'circle:general', null);
     expect(store.getState().agentOrder).toEqual({});
   });
+
+  it('reorders correctly with empty agentOrder when currentAgentIds provided', () => {
+    const store = createHydratedStore();
+    // Simulate first-ever reorder: agentOrder is empty, but UI knows display order
+    store.getState().placeAgent('a3', 'project:p1', 'a1', ['a1', 'a2', 'a3']);
+    expect(store.getState().agentOrder['project:p1']).toEqual(['a3', 'a1', 'a2']);
+  });
+
+  it('reorders correctly with sparse agentOrder when currentAgentIds provided', () => {
+    const store = createHydratedStore();
+    // Partially populated order — only some agents tracked
+    store.getState().placeAgent('b', 'project:p1', null);
+    store.getState().placeAgent('d', 'project:p1', null);
+    expect(store.getState().agentOrder['project:p1']).toEqual(['b', 'd']);
+
+    // Move e before d; UI knows the full display order [b, d, a, c, e]
+    store.getState().placeAgent('e', 'project:p1', 'd', ['b', 'd', 'a', 'c', 'e']);
+    expect(store.getState().agentOrder['project:p1']).toEqual(['b', 'e', 'd', 'a', 'c']);
+  });
+
+  it('cross-circle move with currentAgentIds populates full target order', () => {
+    const store = createHydratedStore();
+    store.getState().addCircle('Favs');
+    // Target circle has agents [x, y] in display but empty agentOrder
+    store.getState().placeAgent('a1', 'circle:1', 'x', ['x', 'y']);
+    expect(store.getState().agentOrder['circle:1']).toEqual(['a1', 'x', 'y']);
+    expect(store.getState().agentCategoryOverrides['a1']).toBe('circle:1');
+  });
 });
 
 describe('moveAgent with agentOrder', () => {

--- a/plugins/lounge/src/state.test.ts
+++ b/plugins/lounge/src/state.test.ts
@@ -627,7 +627,11 @@ describe('circle persistence race condition', () => {
       categoryOrder: ['circle:1', 'project:p1', 'circle:general'],
       categoryEmojis: {},
       renamedLabels: {},
+      agentOrder: {},
       collapsed: [],
+      showTags: true,
+      sidebarCollapsed: false,
+      sidebarWidth: 256,
     });
 
     // Overrides are loaded but categories haven't been re-derived yet
@@ -648,7 +652,11 @@ describe('circle persistence race condition', () => {
       categoryOrder: ['circle:1', 'project:p1', 'circle:general'],
       categoryEmojis: {},
       renamedLabels: {},
+      agentOrder: {},
       collapsed: [],
+      showTags: true,
+      sidebarCollapsed: false,
+      sidebarWidth: 256,
     });
 
     expect(store.getState().hydrated).toBe(true);
@@ -677,7 +685,11 @@ describe('circle persistence race condition', () => {
       categoryOrder: [],
       categoryEmojis: {},
       renamedLabels: {},
+      agentOrder: {},
       collapsed: [],
+      showTags: true,
+      sidebarCollapsed: false,
+      sidebarWidth: 256,
     });
 
     store.getState().deriveCategories([makeProject({ id: 'p1', name: 'P1' })]);
@@ -862,6 +874,188 @@ describe('sortAgentsByOrder', () => {
   });
 });
 
+// ── showTags ────────────────────────────────────────────────────────────
+
+describe('showTags', () => {
+  it('defaults to true', () => {
+    const store = createHydratedStore();
+    expect(store.getState().showTags).toBe(true);
+  });
+
+  it('toggleShowTags flips the value', () => {
+    const store = createHydratedStore();
+    store.getState().toggleShowTags();
+    expect(store.getState().showTags).toBe(false);
+    store.getState().toggleShowTags();
+    expect(store.getState().showTags).toBe(true);
+  });
+
+  it('is included in getPersistedState', () => {
+    const store = createHydratedStore();
+    store.getState().toggleShowTags();
+    const persisted = getPersistedState(store.getState());
+    expect(persisted.showTags).toBe(false);
+  });
+
+  it('hydrates from persisted state', () => {
+    const store = createLoungeStore();
+    store.getState().loadPersistedState({
+      renamedLabels: {},
+      agentCategoryOverrides: {},
+      customCircles: [],
+      nextCircleId: 1,
+      categoryOrder: [],
+      categoryEmojis: {},
+      agentOrder: {},
+      collapsed: [],
+      showTags: false,
+      sidebarCollapsed: false,
+      sidebarWidth: 256,
+    });
+    expect(store.getState().showTags).toBe(false);
+  });
+
+  it('defaults to true when missing from persisted data (backward compat)', () => {
+    const store = createLoungeStore();
+    // Simulate old persisted data without showTags field
+    store.getState().loadPersistedState({
+      renamedLabels: {},
+      agentCategoryOverrides: {},
+      customCircles: [],
+      nextCircleId: 1,
+      categoryOrder: [],
+      categoryEmojis: {},
+      agentOrder: {},
+      collapsed: [],
+    } as unknown as LoungePersistedState);
+    expect(store.getState().showTags).toBe(true);
+  });
+});
+
+// ── sidebarCollapsed ────────────────────────────────────────────────────
+
+describe('sidebarCollapsed', () => {
+  it('defaults to false', () => {
+    const store = createHydratedStore();
+    expect(store.getState().sidebarCollapsed).toBe(false);
+  });
+
+  it('toggleSidebar flips the value', () => {
+    const store = createHydratedStore();
+    store.getState().toggleSidebar();
+    expect(store.getState().sidebarCollapsed).toBe(true);
+    store.getState().toggleSidebar();
+    expect(store.getState().sidebarCollapsed).toBe(false);
+  });
+
+  it('is included in getPersistedState', () => {
+    const store = createHydratedStore();
+    store.getState().toggleSidebar();
+    const persisted = getPersistedState(store.getState());
+    expect(persisted.sidebarCollapsed).toBe(true);
+  });
+
+  it('hydrates from persisted state', () => {
+    const store = createLoungeStore();
+    store.getState().loadPersistedState({
+      renamedLabels: {},
+      agentCategoryOverrides: {},
+      customCircles: [],
+      nextCircleId: 1,
+      categoryOrder: [],
+      categoryEmojis: {},
+      agentOrder: {},
+      collapsed: [],
+      showTags: true,
+      sidebarCollapsed: true,
+      sidebarWidth: 256,
+    });
+    expect(store.getState().sidebarCollapsed).toBe(true);
+  });
+
+  it('defaults to false when missing from persisted data (backward compat)', () => {
+    const store = createLoungeStore();
+    store.getState().loadPersistedState({
+      renamedLabels: {},
+      agentCategoryOverrides: {},
+      customCircles: [],
+      nextCircleId: 1,
+      categoryOrder: [],
+      categoryEmojis: {},
+      agentOrder: {},
+      collapsed: [],
+    } as unknown as LoungePersistedState);
+    expect(store.getState().sidebarCollapsed).toBe(false);
+  });
+});
+
+// ── sidebarWidth ───────────────────────────────────────────────────────
+
+describe('sidebarWidth', () => {
+  it('defaults to 256', () => {
+    const store = createLoungeStore();
+    expect(store.getState().sidebarWidth).toBe(256);
+  });
+
+  it('setSidebarWidth updates the width', () => {
+    const store = createHydratedStore();
+    store.getState().setSidebarWidth(300);
+    expect(store.getState().sidebarWidth).toBe(300);
+  });
+
+  it('clamps to minimum 160', () => {
+    const store = createHydratedStore();
+    store.getState().setSidebarWidth(50);
+    expect(store.getState().sidebarWidth).toBe(160);
+  });
+
+  it('clamps to maximum 480', () => {
+    const store = createHydratedStore();
+    store.getState().setSidebarWidth(600);
+    expect(store.getState().sidebarWidth).toBe(480);
+  });
+
+  it('is included in getPersistedState', () => {
+    const store = createHydratedStore();
+    store.getState().setSidebarWidth(320);
+    const persisted = getPersistedState(store.getState());
+    expect(persisted.sidebarWidth).toBe(320);
+  });
+
+  it('hydrates from persisted state', () => {
+    const store = createLoungeStore();
+    store.getState().loadPersistedState({
+      renamedLabels: {},
+      agentCategoryOverrides: {},
+      customCircles: [],
+      nextCircleId: 1,
+      categoryOrder: [],
+      categoryEmojis: {},
+      agentOrder: {},
+      collapsed: [],
+      showTags: true,
+      sidebarCollapsed: false,
+      sidebarWidth: 350,
+    });
+    expect(store.getState().sidebarWidth).toBe(350);
+  });
+
+  it('defaults to 256 when missing from persisted data (backward compat)', () => {
+    const store = createLoungeStore();
+    store.getState().loadPersistedState({
+      renamedLabels: {},
+      agentCategoryOverrides: {},
+      customCircles: [],
+      nextCircleId: 1,
+      categoryOrder: [],
+      categoryEmojis: {},
+      agentOrder: {},
+      collapsed: [],
+    } as unknown as LoungePersistedState);
+    expect(store.getState().sidebarWidth).toBe(256);
+  });
+});
+
 describe('placeAgent', () => {
   it('places agent before a target agent in the same circle', () => {
     const store = createHydratedStore();
@@ -1002,7 +1196,7 @@ describe('persistence round-trip with agentOrder', () => {
       categoryOrder: [],
       categoryEmojis: {},
       collapsed: [],
-    } as LoungePersistedState);
+    } as unknown as LoungePersistedState);
     expect(store.getState().agentOrder).toEqual({});
   });
 });

--- a/plugins/lounge/src/state.test.ts
+++ b/plugins/lounge/src/state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createLoungeStore, groupAgentsByCategory, disambiguateAgentName, DEFAULT_CIRCLE_ID, DEFAULT_CIRCLE_LABEL, isReservedCircleName, isDefaultCircle, isDuplicateCircleName, getPersistedState } from './state';
+import { createLoungeStore, groupAgentsByCategory, sortAgentsByOrder, disambiguateAgentName, DEFAULT_CIRCLE_ID, DEFAULT_CIRCLE_LABEL, isReservedCircleName, isDefaultCircle, isDuplicateCircleName, getPersistedState } from './state';
 import type { LoungeCategory, LoungePersistedState } from './state';
 import type { AgentInfo, ProjectInfo } from '@clubhouse/plugin-types';
 
@@ -815,5 +815,166 @@ describe('duplicate name validation', () => {
     expect(store.getState().addCircle('')).toBe('');
     expect(store.getState().addCircle('   ')).toBe('');
     expect(store.getState().customCircles).toHaveLength(0);
+  });
+});
+
+describe('sortAgentsByOrder', () => {
+  it('returns agents in order array sequence', () => {
+    const agents = [
+      makeAgent({ id: 'a1', projectId: 'p1' }),
+      makeAgent({ id: 'a2', projectId: 'p1' }),
+      makeAgent({ id: 'a3', projectId: 'p1' }),
+    ];
+    const sorted = sortAgentsByOrder(agents, ['a3', 'a1', 'a2']);
+    expect(sorted.map((a) => a.id)).toEqual(['a3', 'a1', 'a2']);
+  });
+
+  it('appends agents not in order array at the end', () => {
+    const agents = [
+      makeAgent({ id: 'a1', projectId: 'p1' }),
+      makeAgent({ id: 'a2', projectId: 'p1' }),
+      makeAgent({ id: 'a3', projectId: 'p1' }),
+    ];
+    const sorted = sortAgentsByOrder(agents, ['a3']);
+    expect(sorted.map((a) => a.id)).toEqual(['a3', 'a1', 'a2']);
+  });
+
+  it('returns original order when order is undefined', () => {
+    const agents = [
+      makeAgent({ id: 'a1', projectId: 'p1' }),
+      makeAgent({ id: 'a2', projectId: 'p1' }),
+    ];
+    expect(sortAgentsByOrder(agents, undefined)).toEqual(agents);
+  });
+
+  it('returns original order when order is empty', () => {
+    const agents = [
+      makeAgent({ id: 'a1', projectId: 'p1' }),
+      makeAgent({ id: 'a2', projectId: 'p1' }),
+    ];
+    expect(sortAgentsByOrder(agents, [])).toEqual(agents);
+  });
+
+  it('ignores order entries for agents not in the list', () => {
+    const agents = [makeAgent({ id: 'a1', projectId: 'p1' })];
+    const sorted = sortAgentsByOrder(agents, ['a99', 'a1', 'a50']);
+    expect(sorted.map((a) => a.id)).toEqual(['a1']);
+  });
+});
+
+describe('placeAgent', () => {
+  it('places agent before a target agent in the same circle', () => {
+    const store = createHydratedStore();
+    store.getState().deriveCategories([makeProject({ id: 'p1', name: 'P1' })]);
+    // Set up initial order
+    store.getState().placeAgent('a1', 'project:p1', null);
+    store.getState().placeAgent('a2', 'project:p1', null);
+    store.getState().placeAgent('a3', 'project:p1', null);
+    expect(store.getState().agentOrder['project:p1']).toEqual(['a1', 'a2', 'a3']);
+
+    // Move a3 before a1
+    store.getState().placeAgent('a3', 'project:p1', 'a1');
+    expect(store.getState().agentOrder['project:p1']).toEqual(['a3', 'a1', 'a2']);
+  });
+
+  it('appends agent to end when beforeAgentId is null', () => {
+    const store = createHydratedStore();
+    store.getState().placeAgent('a1', 'circle:general', null);
+    store.getState().placeAgent('a2', 'circle:general', null);
+    expect(store.getState().agentOrder['circle:general']).toEqual(['a1', 'a2']);
+  });
+
+  it('moves agent between circles with position', () => {
+    const store = createHydratedStore();
+    store.getState().deriveCategories([makeProject({ id: 'p1', name: 'P1' })]);
+    store.getState().addCircle('Favorites');
+
+    // Place agents in project circle
+    store.getState().placeAgent('a1', 'project:p1', null);
+    store.getState().placeAgent('a2', 'project:p1', null);
+
+    // Place a3 in Favorites
+    store.getState().placeAgent('a3', 'circle:1', null);
+
+    // Move a1 from project to Favorites, before a3
+    store.getState().placeAgent('a1', 'circle:1', 'a3');
+
+    expect(store.getState().agentOrder['circle:1']).toEqual(['a1', 'a3']);
+    expect(store.getState().agentOrder['project:p1']).toEqual(['a2']);
+    expect(store.getState().agentCategoryOverrides['a1']).toBe('circle:1');
+  });
+
+  it('removes agent from old category order on cross-circle move', () => {
+    const store = createHydratedStore();
+    store.getState().placeAgent('a1', 'circle:general', null);
+    store.getState().placeAgent('a2', 'circle:general', null);
+
+    store.getState().addCircle('Test');
+    store.getState().placeAgent('a1', 'circle:1', null);
+
+    expect(store.getState().agentOrder['circle:general']).toEqual(['a2']);
+    expect(store.getState().agentOrder['circle:1']).toEqual(['a1']);
+  });
+
+  it('is blocked before hydration', () => {
+    const store = createLoungeStore();
+    store.getState().placeAgent('a1', 'circle:general', null);
+    expect(store.getState().agentOrder).toEqual({});
+  });
+});
+
+describe('moveAgent with agentOrder', () => {
+  it('appends to target circle order and removes from source', () => {
+    const store = createHydratedStore();
+    store.getState().placeAgent('a1', 'circle:general', null);
+    store.getState().placeAgent('a2', 'circle:general', null);
+
+    store.getState().addCircle('New');
+    store.getState().moveAgent('a1', 'circle:1');
+
+    expect(store.getState().agentOrder['circle:general']).toEqual(['a2']);
+    expect(store.getState().agentOrder['circle:1']).toEqual(['a1']);
+  });
+});
+
+describe('deleteCircle cleans up agentOrder', () => {
+  it('removes the deleted circle from agentOrder', () => {
+    const store = createHydratedStore();
+    store.getState().addCircle('Temp');
+    store.getState().placeAgent('a1', 'circle:1', null);
+    expect(store.getState().agentOrder['circle:1']).toEqual(['a1']);
+
+    store.getState().deleteCircle('circle:1');
+    expect(store.getState().agentOrder['circle:1']).toBeUndefined();
+  });
+});
+
+describe('persistence round-trip with agentOrder', () => {
+  it('persists and restores agentOrder', () => {
+    const store = createHydratedStore();
+    store.getState().placeAgent('a1', 'circle:general', null);
+    store.getState().placeAgent('a2', 'circle:general', null);
+    store.getState().placeAgent('a2', 'circle:general', 'a1');
+
+    const snapshot = getPersistedState(store.getState());
+    expect(snapshot.agentOrder['circle:general']).toEqual(['a2', 'a1']);
+
+    const store2 = createLoungeStore();
+    store2.getState().loadPersistedState(snapshot);
+    expect(store2.getState().agentOrder['circle:general']).toEqual(['a2', 'a1']);
+  });
+
+  it('loadPersistedState handles missing agentOrder gracefully', () => {
+    const store = createLoungeStore();
+    store.getState().loadPersistedState({
+      renamedLabels: {},
+      agentCategoryOverrides: {},
+      customCircles: [],
+      nextCircleId: 1,
+      categoryOrder: [],
+      categoryEmojis: {},
+      collapsed: [],
+    } as LoungePersistedState);
+    expect(store.getState().agentOrder).toEqual({});
   });
 });

--- a/plugins/lounge/src/state.test.ts
+++ b/plugins/lounge/src/state.test.ts
@@ -1,0 +1,732 @@
+import { describe, it, expect } from 'vitest';
+import { createLoungeStore, groupAgentsByCategory, disambiguateAgentName, DEFAULT_CIRCLE_ID, DEFAULT_CIRCLE_LABEL, isReservedCircleName, isDefaultCircle, isDuplicateCircleName, getPersistedState } from './state';
+import type { LoungeCategory, LoungePersistedState } from './state';
+import type { AgentInfo, ProjectInfo } from '@clubhouse/plugin-types';
+
+/** Create a store that is already hydrated (mutations are unblocked). */
+function createHydratedStore() {
+  const store = createLoungeStore();
+  store.setState({ hydrated: true });
+  return store;
+}
+
+function makeAgent(overrides: Partial<AgentInfo> & { id: string; projectId: string }): AgentInfo {
+  return {
+    name: 'agent-1',
+    kind: 'durable',
+    status: 'running',
+    color: 'blue',
+    ...overrides,
+  };
+}
+
+function makeProject(overrides: Partial<ProjectInfo> & { id: string }): ProjectInfo {
+  return {
+    name: overrides.id,
+    path: `/projects/${overrides.id}`,
+    ...overrides,
+  };
+}
+
+describe('createLoungeStore', () => {
+  it('initializes with General circle', () => {
+    const store = createHydratedStore();
+    const state = store.getState();
+    expect(state.categories).toHaveLength(1);
+    expect(state.categories[0]).toEqual({ id: DEFAULT_CIRCLE_ID, label: DEFAULT_CIRCLE_LABEL, emoji: '💬' });
+    expect(state.collapsed.size).toBe(0);
+    expect(state.selectedAgentId).toBeNull();
+    expect(state.selectedProjectId).toBeNull();
+  });
+
+  describe('deriveCategories', () => {
+    it('creates one category per project plus General', () => {
+      const store = createHydratedStore();
+      store.getState().deriveCategories([
+        makeProject({ id: 'proj-1', name: 'Project One' }),
+        makeProject({ id: 'proj-2', name: 'Project Two' }),
+      ]);
+      const { categories } = store.getState();
+      expect(categories).toHaveLength(3);
+      expect(categories[0]).toEqual({ id: 'project:proj-1', label: 'Project One', emoji: '📁', projectId: 'proj-1' });
+      expect(categories[1]).toEqual({ id: 'project:proj-2', label: 'Project Two', emoji: '📁', projectId: 'proj-2' });
+      expect(categories[2]).toEqual({ id: DEFAULT_CIRCLE_ID, label: DEFAULT_CIRCLE_LABEL, emoji: '💬' });
+    });
+
+    it('preserves collapsed state for surviving categories', () => {
+      const store = createHydratedStore();
+      store.getState().deriveCategories([
+        makeProject({ id: 'proj-1' }),
+        makeProject({ id: 'proj-2' }),
+      ]);
+      store.getState().toggleCollapsed('project:proj-1');
+      expect(store.getState().collapsed.has('project:proj-1')).toBe(true);
+
+      // Re-derive with proj-1 still present
+      store.getState().deriveCategories([
+        makeProject({ id: 'proj-1' }),
+        makeProject({ id: 'proj-3' }),
+      ]);
+      expect(store.getState().collapsed.has('project:proj-1')).toBe(true);
+      expect(store.getState().collapsed.has('project:proj-2')).toBe(false);
+    });
+
+    it('removes collapsed state for removed categories', () => {
+      const store = createHydratedStore();
+      store.getState().deriveCategories([makeProject({ id: 'proj-1' })]);
+      store.getState().toggleCollapsed('project:proj-1');
+
+      store.getState().deriveCategories([makeProject({ id: 'proj-2' })]);
+      expect(store.getState().collapsed.has('project:proj-1')).toBe(false);
+    });
+  });
+
+  describe('toggleCollapsed', () => {
+    it('toggles a category collapsed state', () => {
+      const store = createHydratedStore();
+      store.getState().deriveCategories([makeProject({ id: 'proj-1' })]);
+
+      store.getState().toggleCollapsed('project:proj-1');
+      expect(store.getState().collapsed.has('project:proj-1')).toBe(true);
+
+      store.getState().toggleCollapsed('project:proj-1');
+      expect(store.getState().collapsed.has('project:proj-1')).toBe(false);
+    });
+  });
+
+  describe('selectAgent', () => {
+    it('sets selectedAgentId and selectedProjectId', () => {
+      const store = createHydratedStore();
+      store.getState().selectAgent('agent-1', 'proj-1');
+      expect(store.getState().selectedAgentId).toBe('agent-1');
+      expect(store.getState().selectedProjectId).toBe('proj-1');
+    });
+
+    it('clears selection when null', () => {
+      const store = createHydratedStore();
+      store.getState().selectAgent('agent-1', 'proj-1');
+      store.getState().selectAgent(null);
+      expect(store.getState().selectedAgentId).toBeNull();
+      expect(store.getState().selectedProjectId).toBeNull();
+    });
+  });
+
+  describe('renameCategory', () => {
+    it('updates the category label', () => {
+      const store = createHydratedStore();
+      store.getState().deriveCategories([makeProject({ id: 'proj-1', name: 'Original' })]);
+      store.getState().renameCategory('project:proj-1', 'Custom Name');
+      expect(store.getState().categories[0].label).toBe('Custom Name');
+    });
+
+    it('persists renamed label across deriveCategories calls', () => {
+      const store = createHydratedStore();
+      store.getState().deriveCategories([makeProject({ id: 'proj-1', name: 'Original' })]);
+      store.getState().renameCategory('project:proj-1', 'My Label');
+
+      // Re-derive — renamed label should persist
+      store.getState().deriveCategories([makeProject({ id: 'proj-1', name: 'Original' })]);
+      expect(store.getState().categories[0].label).toBe('My Label');
+    });
+
+    it('stores the renamed label in renamedLabels', () => {
+      const store = createHydratedStore();
+      store.getState().deriveCategories([makeProject({ id: 'proj-1' })]);
+      store.getState().renameCategory('project:proj-1', 'Renamed');
+      expect(store.getState().renamedLabels['project:proj-1']).toBe('Renamed');
+    });
+
+    it('does not affect other categories', () => {
+      const store = createHydratedStore();
+      store.getState().deriveCategories([
+        makeProject({ id: 'proj-1', name: 'One' }),
+        makeProject({ id: 'proj-2', name: 'Two' }),
+      ]);
+      store.getState().renameCategory('project:proj-1', 'Renamed One');
+      expect(store.getState().categories[0].label).toBe('Renamed One');
+      expect(store.getState().categories[1].label).toBe('Two');
+    });
+  });
+
+  describe('moveAgent', () => {
+    it('adds an override for the agent', () => {
+      const store = createHydratedStore();
+      store.getState().moveAgent('agent-1', 'project:proj-2');
+      expect(store.getState().agentCategoryOverrides['agent-1']).toBe('project:proj-2');
+    });
+
+    it('overwrites previous override', () => {
+      const store = createHydratedStore();
+      store.getState().moveAgent('agent-1', 'project:proj-2');
+      store.getState().moveAgent('agent-1', 'project:proj-3');
+      expect(store.getState().agentCategoryOverrides['agent-1']).toBe('project:proj-3');
+    });
+
+    it('does not affect other agents', () => {
+      const store = createHydratedStore();
+      store.getState().moveAgent('agent-1', 'project:proj-2');
+      store.getState().moveAgent('agent-2', 'project:proj-3');
+      expect(store.getState().agentCategoryOverrides['agent-1']).toBe('project:proj-2');
+      expect(store.getState().agentCategoryOverrides['agent-2']).toBe('project:proj-3');
+    });
+  });
+});
+
+describe('groupAgentsByCategory', () => {
+  it('groups agents into their project categories', () => {
+    const categories: LoungeCategory[] = [
+      { id: 'project:p1', label: 'P1', projectId: 'p1' },
+      { id: 'project:p2', label: 'P2', projectId: 'p2' },
+    ];
+    const agents = [
+      makeAgent({ id: 'a1', projectId: 'p1' }),
+      makeAgent({ id: 'a2', projectId: 'p2' }),
+      makeAgent({ id: 'a3', projectId: 'p1' }),
+    ];
+
+    const grouped = groupAgentsByCategory(agents, categories);
+    expect(grouped.get('project:p1')).toHaveLength(2);
+    expect(grouped.get('project:p2')).toHaveLength(1);
+  });
+
+  it('returns empty arrays for categories with no agents', () => {
+    const categories: LoungeCategory[] = [
+      { id: 'project:p1', label: 'P1', projectId: 'p1' },
+    ];
+    const grouped = groupAgentsByCategory([], categories);
+    expect(grouped.get('project:p1')).toEqual([]);
+  });
+
+  it('falls unmatched agents into General when present', () => {
+    const categories: LoungeCategory[] = [
+      { id: 'project:p1', label: 'P1', projectId: 'p1' },
+      { id: DEFAULT_CIRCLE_ID, label: DEFAULT_CIRCLE_LABEL },
+    ];
+    const agents = [
+      makeAgent({ id: 'a1', projectId: 'p1' }),
+      makeAgent({ id: 'a2', projectId: 'unknown' }),
+    ];
+
+    const grouped = groupAgentsByCategory(agents, categories);
+    expect(grouped.get('project:p1')).toHaveLength(1);
+    expect(grouped.get(DEFAULT_CIRCLE_ID)).toHaveLength(1);
+  });
+
+  it('drops unmatched agents when General is absent', () => {
+    const categories: LoungeCategory[] = [
+      { id: 'project:p1', label: 'P1', projectId: 'p1' },
+    ];
+    const agents = [
+      makeAgent({ id: 'a1', projectId: 'p1' }),
+      makeAgent({ id: 'a2', projectId: 'unknown' }),
+    ];
+
+    const grouped = groupAgentsByCategory(agents, categories);
+    expect(grouped.get('project:p1')).toHaveLength(1);
+  });
+
+  it('respects overrides to move agent to a different category', () => {
+    const categories: LoungeCategory[] = [
+      { id: 'project:p1', label: 'P1', projectId: 'p1' },
+      { id: 'project:p2', label: 'P2', projectId: 'p2' },
+    ];
+    const agents = [
+      makeAgent({ id: 'a1', projectId: 'p1' }),
+      makeAgent({ id: 'a2', projectId: 'p1' }),
+    ];
+
+    const overrides = { a2: 'project:p2' };
+    const grouped = groupAgentsByCategory(agents, categories, overrides);
+    expect(grouped.get('project:p1')).toHaveLength(1);
+    expect(grouped.get('project:p2')).toHaveLength(1);
+    expect(grouped.get('project:p2')![0].id).toBe('a2');
+  });
+
+  it('ignores overrides pointing to invalid categories', () => {
+    const categories: LoungeCategory[] = [
+      { id: 'project:p1', label: 'P1', projectId: 'p1' },
+    ];
+    const agents = [
+      makeAgent({ id: 'a1', projectId: 'p1' }),
+    ];
+
+    const overrides = { a1: 'project:nonexistent' };
+    const grouped = groupAgentsByCategory(agents, categories, overrides);
+    // Falls back to project-based grouping
+    expect(grouped.get('project:p1')).toHaveLength(1);
+  });
+});
+
+describe('disambiguateAgentName', () => {
+  it('returns plain name when unique', () => {
+    const agents = [
+      makeAgent({ id: 'a1', projectId: 'p1', name: 'alpha' }),
+      makeAgent({ id: 'a2', projectId: 'p1', name: 'beta' }),
+    ];
+    const projects = [makeProject({ id: 'p1', name: 'MyProject' })];
+    expect(disambiguateAgentName(agents[0], agents, projects)).toBe('alpha');
+  });
+
+  it('prepends project name when name is duplicated', () => {
+    const agents = [
+      makeAgent({ id: 'a1', projectId: 'p1', name: 'agent' }),
+      makeAgent({ id: 'a2', projectId: 'p2', name: 'agent' }),
+    ];
+    const projects = [
+      makeProject({ id: 'p1', name: 'Frontend' }),
+      makeProject({ id: 'p2', name: 'Backend' }),
+    ];
+
+    expect(disambiguateAgentName(agents[0], agents, projects)).toBe('Frontend/agent');
+    expect(disambiguateAgentName(agents[1], agents, projects)).toBe('Backend/agent');
+  });
+
+  it('falls back to projectId when project not found', () => {
+    const agents = [
+      makeAgent({ id: 'a1', projectId: 'p1', name: 'agent' }),
+      makeAgent({ id: 'a2', projectId: 'p2', name: 'agent' }),
+    ];
+    expect(disambiguateAgentName(agents[0], agents, [])).toBe('p1/agent');
+  });
+});
+
+describe('default circle (General)', () => {
+  it('isDefaultCircle returns true for the default circle ID', () => {
+    expect(isDefaultCircle(DEFAULT_CIRCLE_ID)).toBe(true);
+    expect(isDefaultCircle('project:p1')).toBe(false);
+    expect(isDefaultCircle('circle:1')).toBe(false);
+  });
+
+  it('renameCategory is a no-op on the default circle', () => {
+    const store = createHydratedStore();
+    store.getState().renameCategory(DEFAULT_CIRCLE_ID, 'Hacked');
+    const general = store.getState().categories.find((c) => c.id === DEFAULT_CIRCLE_ID);
+    expect(general!.label).toBe(DEFAULT_CIRCLE_LABEL);
+  });
+
+  it('renameCategory rejects reserved names on other circles', () => {
+    const store = createHydratedStore();
+    store.getState().deriveCategories([makeProject({ id: 'proj-1', name: 'MyProject' })]);
+    store.getState().renameCategory('project:proj-1', 'General');
+    expect(store.getState().categories[0].label).toBe('MyProject');
+    // case-insensitive
+    store.getState().renameCategory('project:proj-1', 'GENERAL');
+    expect(store.getState().categories[0].label).toBe('MyProject');
+  });
+
+  it('General is always last after deriveCategories', () => {
+    const store = createHydratedStore();
+    store.getState().deriveCategories([
+      makeProject({ id: 'proj-1' }),
+      makeProject({ id: 'proj-2' }),
+    ]);
+    const cats = store.getState().categories;
+    expect(cats[cats.length - 1].id).toBe(DEFAULT_CIRCLE_ID);
+  });
+
+  it('agents with no matching category fall into General', () => {
+    const categories: LoungeCategory[] = [
+      { id: 'project:p1', label: 'P1', projectId: 'p1' },
+      { id: DEFAULT_CIRCLE_ID, label: DEFAULT_CIRCLE_LABEL },
+    ];
+    const agents = [
+      makeAgent({ id: 'a1', projectId: 'p1' }),
+      makeAgent({ id: 'a2', projectId: 'unknown-project' }),
+    ];
+
+    const grouped = groupAgentsByCategory(agents, categories);
+    expect(grouped.get('project:p1')).toHaveLength(1);
+    expect(grouped.get(DEFAULT_CIRCLE_ID)).toHaveLength(1);
+    expect(grouped.get(DEFAULT_CIRCLE_ID)![0].id).toBe('a2');
+  });
+});
+
+describe('isReservedCircleName', () => {
+  it('matches "general" case-insensitively', () => {
+    expect(isReservedCircleName('general')).toBe(true);
+    expect(isReservedCircleName('General')).toBe(true);
+    expect(isReservedCircleName('GENERAL')).toBe(true);
+    expect(isReservedCircleName(' General ')).toBe(true);
+  });
+
+  it('does not match non-reserved names', () => {
+    expect(isReservedCircleName('My Circle')).toBe(false);
+    expect(isReservedCircleName('generals')).toBe(false);
+  });
+});
+
+describe('addCircle', () => {
+  it('adds a custom circle and returns its ID', () => {
+    const store = createHydratedStore();
+    const id = store.getState().addCircle('My Circle');
+    expect(id).toBe('circle:1');
+    expect(store.getState().customCircles).toHaveLength(1);
+    expect(store.getState().customCircles[0]).toEqual({ id: 'circle:1', label: 'My Circle', emoji: '⭐' });
+  });
+
+  it('inserts custom circle before General in categories', () => {
+    const store = createHydratedStore();
+    store.getState().addCircle('Team Chat');
+    const cats = store.getState().categories;
+    expect(cats[cats.length - 1].id).toBe(DEFAULT_CIRCLE_ID);
+    expect(cats[cats.length - 2].label).toBe('Team Chat');
+  });
+
+  it('increments nextCircleId', () => {
+    const store = createHydratedStore();
+    store.getState().addCircle('A');
+    store.getState().addCircle('B');
+    expect(store.getState().nextCircleId).toBe(3);
+    expect(store.getState().customCircles).toHaveLength(2);
+  });
+
+  it('rejects reserved names and returns empty string', () => {
+    const store = createHydratedStore();
+    const id = store.getState().addCircle('General');
+    expect(id).toBe('');
+    expect(store.getState().customCircles).toHaveLength(0);
+  });
+
+  it('preserves custom circles across deriveCategories', () => {
+    const store = createHydratedStore();
+    store.getState().addCircle('Favorites');
+    store.getState().deriveCategories([makeProject({ id: 'proj-1' })]);
+
+    const cats = store.getState().categories;
+    expect(cats.find((c) => c.label === 'Favorites')).toBeDefined();
+    expect(cats[cats.length - 1].id).toBe(DEFAULT_CIRCLE_ID);
+  });
+
+  it('agents can be moved to custom circles', () => {
+    const store = createHydratedStore();
+    const circleId = store.getState().addCircle('VIPs');
+    store.getState().deriveCategories([makeProject({ id: 'p1' })]);
+
+    const categories = store.getState().categories;
+    const agents = [makeAgent({ id: 'a1', projectId: 'p1' })];
+    const overrides = { a1: circleId };
+
+    const grouped = groupAgentsByCategory(agents, categories, overrides);
+    expect(grouped.get(circleId)).toHaveLength(1);
+    expect(grouped.get('project:p1')).toHaveLength(0);
+  });
+});
+
+describe('reorderCategory', () => {
+  it('moves a category before the target', () => {
+    const store = createHydratedStore();
+    store.getState().deriveCategories([
+      makeProject({ id: 'p1', name: 'P1' }),
+      makeProject({ id: 'p2', name: 'P2' }),
+      makeProject({ id: 'p3', name: 'P3' }),
+    ]);
+
+    // Move p3 before p1
+    store.getState().reorderCategory('project:p3', 'project:p1');
+    const ids = store.getState().categories.map((c) => c.id);
+    expect(ids).toEqual(['project:p3', 'project:p1', 'project:p2', DEFAULT_CIRCLE_ID]);
+  });
+
+  it('keeps General at the end after reorder', () => {
+    const store = createHydratedStore();
+    store.getState().deriveCategories([
+      makeProject({ id: 'p1' }),
+      makeProject({ id: 'p2' }),
+    ]);
+    store.getState().reorderCategory('project:p2', 'project:p1');
+    const cats = store.getState().categories;
+    expect(cats[cats.length - 1].id).toBe(DEFAULT_CIRCLE_ID);
+  });
+
+  it('is a no-op when dragging General', () => {
+    const store = createHydratedStore();
+    store.getState().deriveCategories([makeProject({ id: 'p1' })]);
+    const before = store.getState().categories.map((c) => c.id);
+    store.getState().reorderCategory(DEFAULT_CIRCLE_ID, 'project:p1');
+    const after = store.getState().categories.map((c) => c.id);
+    expect(after).toEqual(before);
+  });
+
+  it('is a no-op when dropping onto General', () => {
+    const store = createHydratedStore();
+    store.getState().deriveCategories([makeProject({ id: 'p1' })]);
+    const before = store.getState().categories.map((c) => c.id);
+    store.getState().reorderCategory('project:p1', DEFAULT_CIRCLE_ID);
+    const after = store.getState().categories.map((c) => c.id);
+    expect(after).toEqual(before);
+  });
+
+  it('is a no-op for same category', () => {
+    const store = createHydratedStore();
+    store.getState().deriveCategories([makeProject({ id: 'p1' })]);
+    const before = store.getState().categories.map((c) => c.id);
+    store.getState().reorderCategory('project:p1', 'project:p1');
+    const after = store.getState().categories.map((c) => c.id);
+    expect(after).toEqual(before);
+  });
+
+  it('persists order across deriveCategories', () => {
+    const store = createHydratedStore();
+    store.getState().deriveCategories([
+      makeProject({ id: 'p1', name: 'P1' }),
+      makeProject({ id: 'p2', name: 'P2' }),
+    ]);
+    store.getState().reorderCategory('project:p2', 'project:p1');
+
+    // Re-derive — order should be preserved
+    store.getState().deriveCategories([
+      makeProject({ id: 'p1', name: 'P1' }),
+      makeProject({ id: 'p2', name: 'P2' }),
+    ]);
+    const ids = store.getState().categories.map((c) => c.id);
+    expect(ids).toEqual(['project:p2', 'project:p1', DEFAULT_CIRCLE_ID]);
+  });
+});
+
+describe('setCategoryEmoji', () => {
+  it('changes emoji on a project circle', () => {
+    const store = createHydratedStore();
+    store.getState().deriveCategories([makeProject({ id: 'p1' })]);
+    store.getState().setCategoryEmoji('project:p1', '🔥');
+    expect(store.getState().categories[0].emoji).toBe('🔥');
+  });
+
+  it('changes emoji on the General circle', () => {
+    const store = createHydratedStore();
+    store.getState().setCategoryEmoji(DEFAULT_CIRCLE_ID, '🏠');
+    expect(store.getState().categories.find((c) => c.id === DEFAULT_CIRCLE_ID)!.emoji).toBe('🏠');
+  });
+
+  it('changes emoji on a custom circle', () => {
+    const store = createHydratedStore();
+    const id = store.getState().addCircle('VIPs');
+    store.getState().setCategoryEmoji(id, '💎');
+    expect(store.getState().categories.find((c) => c.id === id)!.emoji).toBe('💎');
+    expect(store.getState().customCircles.find((c) => c.id === id)!.emoji).toBe('💎');
+  });
+
+  it('persists emoji across deriveCategories', () => {
+    const store = createHydratedStore();
+    store.getState().deriveCategories([makeProject({ id: 'p1' })]);
+    store.getState().setCategoryEmoji('project:p1', '🚀');
+
+    store.getState().deriveCategories([makeProject({ id: 'p1' })]);
+    expect(store.getState().categories[0].emoji).toBe('🚀');
+  });
+
+  it('stores emoji in categoryEmojis', () => {
+    const store = createHydratedStore();
+    store.getState().deriveCategories([makeProject({ id: 'p1' })]);
+    store.getState().setCategoryEmoji('project:p1', '🎯');
+    expect(store.getState().categoryEmojis['project:p1']).toBe('🎯');
+  });
+});
+
+describe('persistence (getPersistedState / loadPersistedState)', () => {
+  it('round-trips state through persist/load', () => {
+    const store = createHydratedStore();
+    store.getState().deriveCategories([makeProject({ id: 'p1', name: 'P1' })]);
+    store.getState().addCircle('Favorites');
+    store.getState().renameCategory('project:p1', 'My Proj');
+    store.getState().moveAgent('a1', 'circle:1');
+    store.getState().setCategoryEmoji('project:p1', '🚀');
+    store.getState().toggleCollapsed('project:p1');
+
+    const snapshot = getPersistedState(store.getState());
+
+    // Create a fresh store and load the snapshot
+    const store2 = createLoungeStore();
+    store2.getState().loadPersistedState(snapshot);
+
+    const s2 = store2.getState();
+    expect(s2.renamedLabels['project:p1']).toBe('My Proj');
+    expect(s2.agentCategoryOverrides['a1']).toBe('circle:1');
+    expect(s2.customCircles).toHaveLength(1);
+    expect(s2.customCircles[0].label).toBe('Favorites');
+    expect(s2.nextCircleId).toBe(2);
+    expect(s2.categoryEmojis['project:p1']).toBe('🚀');
+    expect(s2.collapsed.has('project:p1')).toBe(true);
+  });
+
+  it('getPersistedState serializes collapsed as array', () => {
+    const store = createHydratedStore();
+    store.getState().deriveCategories([makeProject({ id: 'p1' })]);
+    store.getState().toggleCollapsed('project:p1');
+
+    const snapshot = getPersistedState(store.getState());
+    expect(Array.isArray(snapshot.collapsed)).toBe(true);
+    expect(snapshot.collapsed).toContain('project:p1');
+  });
+
+  it('loadPersistedState handles missing fields gracefully', () => {
+    const store = createHydratedStore();
+    store.getState().loadPersistedState({} as LoungePersistedState);
+
+    const s = store.getState();
+    expect(s.renamedLabels).toEqual({});
+    expect(s.customCircles).toEqual([]);
+    expect(s.categoryOrder).toEqual([]);
+    expect(s.collapsed.size).toBe(0);
+  });
+});
+
+describe('hydration guard', () => {
+  it('starts un-hydrated', () => {
+    const store = createLoungeStore();
+    expect(store.getState().hydrated).toBe(false);
+  });
+
+  it('blocks mutations before hydration', () => {
+    const store = createLoungeStore();
+    store.getState().renameCategory('project:p1', 'X');
+    expect(store.getState().renamedLabels).toEqual({});
+
+    store.getState().moveAgent('a1', 'circle:1');
+    expect(store.getState().agentCategoryOverrides).toEqual({});
+
+    const id = store.getState().addCircle('Test');
+    expect(id).toBe('');
+    expect(store.getState().customCircles).toHaveLength(0);
+  });
+
+  it('unblocks after loadPersistedState', () => {
+    const store = createLoungeStore();
+    store.getState().loadPersistedState({ collapsed: [] } as unknown as LoungePersistedState);
+    expect(store.getState().hydrated).toBe(true);
+
+    store.getState().addCircle('Now works');
+    expect(store.getState().customCircles).toHaveLength(1);
+  });
+
+  it('allows deriveCategories and selectAgent before hydration', () => {
+    const store = createLoungeStore();
+    store.getState().deriveCategories([makeProject({ id: 'p1', name: 'P1' })]);
+    expect(store.getState().categories).toHaveLength(2);
+
+    store.getState().selectAgent('a1', 'p1');
+    expect(store.getState().selectedAgentId).toBe('a1');
+  });
+});
+
+describe('General project name collision', () => {
+  it('disambiguates project named General', () => {
+    const store = createHydratedStore();
+    store.getState().deriveCategories([makeProject({ id: 'p1', name: 'General' })]);
+    const cats = store.getState().categories;
+    const projectCat = cats.find((c) => c.id === 'project:p1');
+    expect(projectCat?.label).toBe('General (project)');
+    // The default circle should remain as-is
+    const general = cats.find((c) => c.id === DEFAULT_CIRCLE_ID);
+    expect(general?.label).toBe(DEFAULT_CIRCLE_LABEL);
+  });
+
+  it('does not disambiguate projects with non-reserved names', () => {
+    const store = createHydratedStore();
+    store.getState().deriveCategories([makeProject({ id: 'p1', name: 'My Project' })]);
+    const cats = store.getState().categories;
+    expect(cats[0].label).toBe('My Project');
+  });
+});
+
+describe('deleteCircle', () => {
+  it('removes a custom circle', () => {
+    const store = createHydratedStore();
+    const id = store.getState().addCircle('Temp');
+    expect(store.getState().customCircles).toHaveLength(1);
+    store.getState().deleteCircle(id);
+    expect(store.getState().customCircles).toHaveLength(0);
+    expect(store.getState().categories.find((c) => c.id === id)).toBeUndefined();
+  });
+
+  it('moves agents back to General when their circle is deleted', () => {
+    const store = createHydratedStore();
+    const id = store.getState().addCircle('VIPs');
+    store.getState().moveAgent('a1', id);
+    expect(store.getState().agentCategoryOverrides['a1']).toBe(id);
+    store.getState().deleteCircle(id);
+    expect(store.getState().agentCategoryOverrides['a1']).toBeUndefined();
+  });
+
+  it('cannot delete the General circle', () => {
+    const store = createHydratedStore();
+    store.getState().deleteCircle(DEFAULT_CIRCLE_ID);
+    expect(store.getState().categories.find((c) => c.id === DEFAULT_CIRCLE_ID)).toBeDefined();
+  });
+
+  it('cannot delete project-derived circles', () => {
+    const store = createHydratedStore();
+    store.getState().deriveCategories([makeProject({ id: 'p1' })]);
+    store.getState().deleteCircle('project:p1');
+    expect(store.getState().categories.find((c) => c.id === 'project:p1')).toBeDefined();
+  });
+
+  it('cleans up emojis, labels, order, and collapsed state', () => {
+    const store = createHydratedStore();
+    const id = store.getState().addCircle('Temp');
+    store.getState().setCategoryEmoji(id, '🔥');
+    store.getState().renameCategory(id, 'Renamed');
+    store.getState().toggleCollapsed(id);
+    store.getState().deleteCircle(id);
+    expect(store.getState().categoryEmojis[id]).toBeUndefined();
+    expect(store.getState().renamedLabels[id]).toBeUndefined();
+    expect(store.getState().collapsed.has(id)).toBe(false);
+  });
+});
+
+describe('duplicate name validation', () => {
+  it('isDuplicateCircleName detects duplicates case-insensitively', () => {
+    const cats: LoungeCategory[] = [
+      { id: 'circle:1', label: 'Favorites' },
+      { id: DEFAULT_CIRCLE_ID, label: 'General' },
+    ];
+    expect(isDuplicateCircleName('Favorites', cats)).toBe(true);
+    expect(isDuplicateCircleName('favorites', cats)).toBe(true);
+    expect(isDuplicateCircleName('FAVORITES', cats)).toBe(true);
+    expect(isDuplicateCircleName('Something else', cats)).toBe(false);
+  });
+
+  it('isDuplicateCircleName excludes a specific ID', () => {
+    const cats: LoungeCategory[] = [
+      { id: 'circle:1', label: 'Favorites' },
+    ];
+    expect(isDuplicateCircleName('Favorites', cats, 'circle:1')).toBe(false);
+    expect(isDuplicateCircleName('Favorites', cats, 'circle:2')).toBe(true);
+  });
+
+  it('addCircle rejects duplicate names', () => {
+    const store = createHydratedStore();
+    store.getState().addCircle('Favorites');
+    const id = store.getState().addCircle('Favorites');
+    expect(id).toBe('');
+    expect(store.getState().customCircles).toHaveLength(1);
+  });
+
+  it('addCircle rejects duplicate names case-insensitively', () => {
+    const store = createHydratedStore();
+    store.getState().addCircle('Favorites');
+    const id = store.getState().addCircle('favorites');
+    expect(id).toBe('');
+  });
+
+  it('renameCategory rejects duplicate names', () => {
+    const store = createHydratedStore();
+    store.getState().addCircle('Alpha');
+    store.getState().addCircle('Beta');
+    store.getState().renameCategory('circle:2', 'Alpha');
+    expect(store.getState().categories.find((c) => c.id === 'circle:2')?.label).toBe('Beta');
+  });
+
+  it('renameCategory allows same name on the same circle (no-op)', () => {
+    const store = createHydratedStore();
+    store.getState().addCircle('Alpha');
+    store.getState().renameCategory('circle:1', 'Alpha');
+    expect(store.getState().categories.find((c) => c.id === 'circle:1')?.label).toBe('Alpha');
+  });
+
+  it('addCircle rejects empty names', () => {
+    const store = createHydratedStore();
+    expect(store.getState().addCircle('')).toBe('');
+    expect(store.getState().addCircle('   ')).toBe('');
+    expect(store.getState().customCircles).toHaveLength(0);
+  });
+});

--- a/plugins/lounge/src/state.ts
+++ b/plugins/lounge/src/state.ts
@@ -1,0 +1,410 @@
+import { create } from 'zustand';
+import type { AgentInfo, ProjectInfo } from '@clubhouse/plugin-types';
+
+// ── Constants ────────────────────────────────────────────────────────────
+
+/** The permanent catch-all circle ID. Cannot be renamed or deleted. */
+export const DEFAULT_CIRCLE_ID = 'circle:general';
+export const DEFAULT_CIRCLE_LABEL = 'General';
+export const DEFAULT_CIRCLE_EMOJI = '💬';
+export const DEFAULT_PROJECT_EMOJI = '📁';
+export const DEFAULT_CUSTOM_EMOJI = '⭐';
+
+/** Reserved circle names (case-insensitive). */
+const RESERVED_NAMES = new Set(['general']);
+
+/** Check whether a label collides with a reserved name. */
+export function isReservedCircleName(label: string): boolean {
+  return RESERVED_NAMES.has(label.toLowerCase().trim());
+}
+
+/** Returns true if the category is the permanent default circle. */
+export function isDefaultCircle(categoryId: string): boolean {
+  return categoryId === DEFAULT_CIRCLE_ID;
+}
+
+/** Check whether a label already exists among current categories (case-insensitive). */
+export function isDuplicateCircleName(label: string, categories: LoungeCategory[], excludeId?: string): boolean {
+  const normalized = label.toLowerCase().trim();
+  return categories.some((c) => c.id !== excludeId && c.label.toLowerCase().trim() === normalized);
+}
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+export interface LoungeCategory {
+  id: string;
+  label: string;
+  /** Emoji icon displayed before the label. */
+  emoji?: string;
+  /** When derived from a project, holds the project ID. Absent for custom circles. */
+  projectId?: string;
+}
+
+export interface LoungeState {
+  categories: LoungeCategory[];
+  /** Set of collapsed category IDs. */
+  collapsed: Set<string>;
+  /** Currently selected agent ID (displayed in the content area). */
+  selectedAgentId: string | null;
+  /** Project ID of the selected agent (for cross-project navigation). */
+  selectedProjectId: string | null;
+  /** User-defined label overrides keyed by category ID. */
+  renamedLabels: Record<string, string>;
+  /** Agent-to-category overrides: agentId → categoryId. */
+  agentCategoryOverrides: Record<string, string>;
+  /** Custom user-created circles (persisted independently of projects). */
+  customCircles: LoungeCategory[];
+  /** Counter for generating unique custom circle IDs. */
+  nextCircleId: number;
+  /** User-defined category ordering (persisted across derive calls). */
+  categoryOrder: string[];
+  /** User-defined emoji overrides keyed by category ID. */
+  categoryEmojis: Record<string, string>;
+  /** Whether persisted state has been loaded (blocks mutations until true). */
+  hydrated: boolean;
+
+  // Actions
+  deriveCategories(projects: ProjectInfo[]): void;
+  toggleCollapsed(categoryId: string): void;
+  selectAgent(agentId: string | null, projectId?: string | null): void;
+  renameCategory(categoryId: string, label: string): void;
+  moveAgent(agentId: string, targetCategoryId: string): void;
+  addCircle(label: string): string;
+  deleteCircle(circleId: string): void;
+  reorderCategory(fromId: string, toId: string): void;
+  setCategoryEmoji(categoryId: string, emoji: string): void;
+  /** Hydrate store from persisted data. */
+  loadPersistedState(data: LoungePersistedState): void;
+}
+
+/** Subset of LoungeState that is persisted to storage. */
+export interface LoungePersistedState {
+  renamedLabels: Record<string, string>;
+  agentCategoryOverrides: Record<string, string>;
+  customCircles: LoungeCategory[];
+  nextCircleId: number;
+  categoryOrder: string[];
+  categoryEmojis: Record<string, string>;
+  collapsed: string[];
+}
+
+/** Extract the persistable subset from the store. */
+export function getPersistedState(state: LoungeState): LoungePersistedState {
+  return {
+    renamedLabels: state.renamedLabels,
+    agentCategoryOverrides: state.agentCategoryOverrides,
+    customCircles: state.customCircles,
+    nextCircleId: state.nextCircleId,
+    categoryOrder: state.categoryOrder,
+    categoryEmojis: state.categoryEmojis,
+    collapsed: Array.from(state.collapsed),
+  };
+}
+
+/**
+ * Group agents by their categories. Returns a map of categoryId → agents.
+ * Agents belong to the category matching their projectId, unless overridden.
+ * Agents with no matching category fall into the default "General" circle.
+ */
+export function groupAgentsByCategory(
+  agents: AgentInfo[],
+  categories: LoungeCategory[],
+  overrides: Record<string, string> = {},
+): Map<string, AgentInfo[]> {
+  const projectToCategory = new Map<string, string>();
+  for (const cat of categories) {
+    if (cat.projectId) {
+      projectToCategory.set(cat.projectId, cat.id);
+    }
+  }
+
+  const validCategoryIds = new Set(categories.map((c) => c.id));
+
+  const groups = new Map<string, AgentInfo[]>();
+  for (const cat of categories) {
+    groups.set(cat.id, []);
+  }
+
+  for (const agent of agents) {
+    const overrideCatId = overrides[agent.id];
+    // Use override if it points to a valid category, otherwise fall back to project
+    const catId = (overrideCatId && validCategoryIds.has(overrideCatId))
+      ? overrideCatId
+      : projectToCategory.get(agent.projectId);
+    if (catId && groups.has(catId)) {
+      groups.get(catId)!.push(agent);
+    } else if (groups.has(DEFAULT_CIRCLE_ID)) {
+      // Catch-all: agents with no matching category go to General
+      groups.get(DEFAULT_CIRCLE_ID)!.push(agent);
+    }
+  }
+
+  return groups;
+}
+
+/**
+ * Build a display name for an agent, prepending "project/" if the agent's
+ * name is duplicated within the same category grouping.
+ */
+export function disambiguateAgentName(
+  agent: AgentInfo,
+  allAgents: AgentInfo[],
+  projects: ProjectInfo[],
+): string {
+  const sameNameAgents = allAgents.filter((a) => a.name === agent.name);
+  if (sameNameAgents.length <= 1) return agent.name;
+
+  const project = projects.find((p) => p.id === agent.projectId);
+  const projectLabel = project?.name ?? agent.projectId;
+  return `${projectLabel}/${agent.name}`;
+}
+
+// ── Default circle (always present) ──────────────────────────────────────
+
+const GENERAL_CIRCLE: LoungeCategory = { id: DEFAULT_CIRCLE_ID, label: DEFAULT_CIRCLE_LABEL, emoji: DEFAULT_CIRCLE_EMOJI };
+
+/**
+ * Apply user-defined order to categories. Categories not in the order list
+ * are appended in their natural position. General is always forced to the end.
+ */
+function applyCategoryOrder(categories: LoungeCategory[], order: string[]): LoungeCategory[] {
+  if (order.length === 0) return categories;
+
+  const byId = new Map(categories.map((c) => [c.id, c]));
+  const result: LoungeCategory[] = [];
+  const placed = new Set<string>();
+
+  // Place categories that appear in the order list
+  for (const id of order) {
+    if (id === DEFAULT_CIRCLE_ID) continue; // General always last
+    const cat = byId.get(id);
+    if (cat) {
+      result.push(cat);
+      placed.add(id);
+    }
+  }
+
+  // Append any remaining categories not in the order (except General)
+  for (const cat of categories) {
+    if (!placed.has(cat.id) && cat.id !== DEFAULT_CIRCLE_ID) {
+      result.push(cat);
+    }
+  }
+
+  // General always last
+  const general = byId.get(DEFAULT_CIRCLE_ID);
+  if (general) result.push(general);
+
+  return result;
+}
+
+// ── Store ────────────────────────────────────────────────────────────────
+
+export const createLoungeStore = () =>
+  create<LoungeState>((set, get) => ({
+    categories: [GENERAL_CIRCLE],
+    collapsed: new Set<string>(),
+    selectedAgentId: null,
+    selectedProjectId: null,
+    renamedLabels: {},
+    agentCategoryOverrides: {},
+    customCircles: [],
+    nextCircleId: 1,
+    categoryOrder: [],
+    categoryEmojis: {},
+    hydrated: false,
+
+    deriveCategories(projects: ProjectInfo[]) {
+      set((state) => {
+        const projectCategories: LoungeCategory[] = projects.map((p) => {
+          const catId = `project:${p.id}`;
+          // Disambiguate project labels that collide with reserved names
+          const rawLabel = state.renamedLabels[catId] ?? p.name;
+          const label = isReservedCircleName(rawLabel) ? `${rawLabel} (project)` : rawLabel;
+          return {
+            id: catId,
+            label,
+            emoji: state.categoryEmojis[catId] ?? DEFAULT_PROJECT_EMOJI,
+            projectId: p.id,
+          };
+        });
+
+        // Apply emoji overrides to custom circles
+        const customWithEmojis = state.customCircles.map((c) => ({
+          ...c,
+          emoji: state.categoryEmojis[c.id] ?? c.emoji,
+        }));
+
+        // Apply emoji override to General
+        const general: LoungeCategory = {
+          ...GENERAL_CIRCLE,
+          emoji: state.categoryEmojis[DEFAULT_CIRCLE_ID] ?? GENERAL_CIRCLE.emoji,
+        };
+
+        // Merge all categories, then apply saved order
+        const unordered = [...projectCategories, ...customWithEmojis, general];
+        const newCategories = applyCategoryOrder(unordered, state.categoryOrder);
+
+        // Preserve collapsed state for categories that still exist
+        const newIds = new Set(newCategories.map((c) => c.id));
+        const newCollapsed = new Set<string>();
+        for (const id of state.collapsed) {
+          if (newIds.has(id)) newCollapsed.add(id);
+        }
+
+        return { categories: newCategories, collapsed: newCollapsed };
+      });
+    },
+
+    toggleCollapsed(categoryId: string) {
+      set((state) => {
+        const next = new Set(state.collapsed);
+        if (next.has(categoryId)) {
+          next.delete(categoryId);
+        } else {
+          next.add(categoryId);
+        }
+        return { collapsed: next };
+      });
+    },
+
+    selectAgent(agentId: string | null, projectId?: string | null) {
+      set({ selectedAgentId: agentId, selectedProjectId: projectId ?? null });
+    },
+
+    renameCategory(categoryId: string, label: string) {
+      // Cannot rename the default circle
+      if (isDefaultCircle(categoryId)) return;
+      // Cannot use a reserved name or empty string
+      if (!label.trim() || isReservedCircleName(label)) return;
+      // Block until hydrated to avoid overwriting persisted state
+      if (!get().hydrated) return;
+      // Cannot use a duplicate name
+      if (isDuplicateCircleName(label, get().categories, categoryId)) return;
+
+      set((state) => {
+        const newLabels = { ...state.renamedLabels, [categoryId]: label };
+        const newCategories = state.categories.map((c) =>
+          c.id === categoryId ? { ...c, label } : c,
+        );
+        // Also update the custom circle source-of-truth if it's a custom one
+        const newCustomCircles = state.customCircles.map((c) =>
+          c.id === categoryId ? { ...c, label } : c,
+        );
+        return { renamedLabels: newLabels, categories: newCategories, customCircles: newCustomCircles };
+      });
+    },
+
+    moveAgent(agentId: string, targetCategoryId: string) {
+      if (!get().hydrated) return;
+      set((state) => ({
+        agentCategoryOverrides: { ...state.agentCategoryOverrides, [agentId]: targetCategoryId },
+      }));
+    },
+
+    addCircle(label: string): string {
+      // Reject empty, reserved, or duplicate names
+      if (!label.trim()) return '';
+      if (isReservedCircleName(label)) return '';
+      if (!get().hydrated) return '';
+      if (isDuplicateCircleName(label, get().categories)) return '';
+
+      let newId = '';
+      set((state) => {
+        const id = `circle:${state.nextCircleId}`;
+        newId = id;
+        const circle: LoungeCategory = { id, label, emoji: DEFAULT_CUSTOM_EMOJI };
+        const newCustomCircles = [...state.customCircles, circle];
+        // Insert before General (General is always last)
+        const cats = state.categories.filter((c) => c.id !== DEFAULT_CIRCLE_ID);
+        return {
+          customCircles: newCustomCircles,
+          categories: [...cats, circle, GENERAL_CIRCLE],
+          nextCircleId: state.nextCircleId + 1,
+        };
+      });
+      return newId;
+    },
+
+    deleteCircle(circleId: string) {
+      // Cannot delete the default circle or project-derived circles
+      if (isDefaultCircle(circleId)) return;
+      if (!circleId.startsWith('circle:')) return;
+      if (!get().hydrated) return;
+
+      set((state) => {
+        const newCustomCircles = state.customCircles.filter((c) => c.id !== circleId);
+        const newCategories = state.categories.filter((c) => c.id !== circleId);
+        // Move any agents assigned to this circle back to General
+        const newOverrides = { ...state.agentCategoryOverrides };
+        for (const [agentId, catId] of Object.entries(newOverrides)) {
+          if (catId === circleId) delete newOverrides[agentId];
+        }
+        const newOrder = state.categoryOrder.filter((id) => id !== circleId);
+        const { [circleId]: _emoji, ...newEmojis } = state.categoryEmojis;
+        const { [circleId]: _label, ...newLabels } = state.renamedLabels;
+        const newCollapsed = new Set(state.collapsed);
+        newCollapsed.delete(circleId);
+        return {
+          customCircles: newCustomCircles,
+          categories: newCategories,
+          agentCategoryOverrides: newOverrides,
+          categoryOrder: newOrder,
+          categoryEmojis: newEmojis,
+          renamedLabels: newLabels,
+          collapsed: newCollapsed,
+        };
+      });
+    },
+
+    reorderCategory(fromId: string, toId: string) {
+      // Cannot move General
+      if (isDefaultCircle(fromId) || isDefaultCircle(toId)) return;
+      if (fromId === toId) return;
+      if (!get().hydrated) return;
+
+      set((state) => {
+        const cats = state.categories.filter((c) => c.id !== DEFAULT_CIRCLE_ID);
+        const fromIdx = cats.findIndex((c) => c.id === fromId);
+        const toIdx = cats.findIndex((c) => c.id === toId);
+        if (fromIdx === -1 || toIdx === -1) return state;
+
+        const reordered = [...cats];
+        const [moved] = reordered.splice(fromIdx, 1);
+        reordered.splice(toIdx, 0, moved);
+        reordered.push(GENERAL_CIRCLE);
+
+        return {
+          categories: reordered,
+          categoryOrder: reordered.map((c) => c.id),
+        };
+      });
+    },
+
+    setCategoryEmoji(categoryId: string, emoji: string) {
+      if (!get().hydrated) return;
+      set((state) => {
+        const newEmojis = { ...state.categoryEmojis, [categoryId]: emoji };
+        const newCategories = state.categories.map((c) =>
+          c.id === categoryId ? { ...c, emoji } : c,
+        );
+        const newCustomCircles = state.customCircles.map((c) =>
+          c.id === categoryId ? { ...c, emoji } : c,
+        );
+        return { categoryEmojis: newEmojis, categories: newCategories, customCircles: newCustomCircles };
+      });
+    },
+
+    loadPersistedState(data: LoungePersistedState) {
+      set({
+        renamedLabels: data.renamedLabels ?? {},
+        agentCategoryOverrides: data.agentCategoryOverrides ?? {},
+        customCircles: data.customCircles ?? [],
+        nextCircleId: data.nextCircleId ?? 1,
+        categoryOrder: data.categoryOrder ?? [],
+        categoryEmojis: data.categoryEmojis ?? {},
+        collapsed: new Set(data.collapsed ?? []),
+        hydrated: true,
+      });
+    },
+  }));

--- a/plugins/lounge/src/state.ts
+++ b/plugins/lounge/src/state.ts
@@ -71,7 +71,7 @@ export interface LoungeState {
   selectAgent(agentId: string | null, projectId?: string | null): void;
   renameCategory(categoryId: string, label: string): void;
   moveAgent(agentId: string, targetCategoryId: string): void;
-  placeAgent(agentId: string, targetCategoryId: string, beforeAgentId: string | null): void;
+  placeAgent(agentId: string, targetCategoryId: string, beforeAgentId: string | null, currentAgentIds?: string[]): void;
   addCircle(label: string): string;
   deleteCircle(circleId: string): void;
   reorderCategory(fromId: string, toId: string): void;
@@ -341,7 +341,7 @@ export const createLoungeStore = () =>
       });
     },
 
-    placeAgent(agentId: string, targetCategoryId: string, beforeAgentId: string | null) {
+    placeAgent(agentId: string, targetCategoryId: string, beforeAgentId: string | null, currentAgentIds?: string[]) {
       if (!get().hydrated) return;
       set((state) => {
         const newAgentOrder = { ...state.agentOrder };
@@ -351,8 +351,14 @@ export const createLoungeStore = () =>
             newAgentOrder[catId] = order.filter((id) => id !== agentId);
           }
         }
-        // Insert into target category at position
-        const targetOrder = [...(newAgentOrder[targetCategoryId] ?? [])];
+        // Build full target order: use currentAgentIds (display order) when
+        // available so the splice anchor is always found, avoiding sparse-order bugs.
+        let targetOrder: string[];
+        if (currentAgentIds) {
+          targetOrder = currentAgentIds.filter((id) => id !== agentId);
+        } else {
+          targetOrder = [...(newAgentOrder[targetCategoryId] ?? [])];
+        }
         if (beforeAgentId) {
           const idx = targetOrder.indexOf(beforeAgentId);
           if (idx >= 0) {

--- a/plugins/lounge/src/state.ts
+++ b/plugins/lounge/src/state.ts
@@ -60,6 +60,8 @@ export interface LoungeState {
   categoryOrder: string[];
   /** User-defined emoji overrides keyed by category ID. */
   categoryEmojis: Record<string, string>;
+  /** Per-circle agent ordering: categoryId → ordered agentId array. */
+  agentOrder: Record<string, string[]>;
   /** Whether persisted state has been loaded (blocks mutations until true). */
   hydrated: boolean;
 
@@ -69,6 +71,7 @@ export interface LoungeState {
   selectAgent(agentId: string | null, projectId?: string | null): void;
   renameCategory(categoryId: string, label: string): void;
   moveAgent(agentId: string, targetCategoryId: string): void;
+  placeAgent(agentId: string, targetCategoryId: string, beforeAgentId: string | null): void;
   addCircle(label: string): string;
   deleteCircle(circleId: string): void;
   reorderCategory(fromId: string, toId: string): void;
@@ -85,6 +88,7 @@ export interface LoungePersistedState {
   nextCircleId: number;
   categoryOrder: string[];
   categoryEmojis: Record<string, string>;
+  agentOrder: Record<string, string[]>;
   collapsed: string[];
 }
 
@@ -97,6 +101,7 @@ export function getPersistedState(state: LoungeState): LoungePersistedState {
     nextCircleId: state.nextCircleId,
     categoryOrder: state.categoryOrder,
     categoryEmojis: state.categoryEmojis,
+    agentOrder: state.agentOrder,
     collapsed: Array.from(state.collapsed),
   };
 }
@@ -140,6 +145,26 @@ export function groupAgentsByCategory(
   }
 
   return groups;
+}
+
+/**
+ * Sort agents within a category according to a persisted order array.
+ * Agents in the order come first (in that order); the rest append in their original order.
+ */
+export function sortAgentsByOrder(agents: AgentInfo[], order: string[] | undefined): AgentInfo[] {
+  if (!order || order.length === 0) return agents;
+  const posMap = new Map(order.map((id, i) => [id, i]));
+  const ordered: AgentInfo[] = [];
+  const unordered: AgentInfo[] = [];
+  for (const agent of agents) {
+    if (posMap.has(agent.id)) {
+      ordered.push(agent);
+    } else {
+      unordered.push(agent);
+    }
+  }
+  ordered.sort((a, b) => posMap.get(a.id)! - posMap.get(b.id)!);
+  return [...ordered, ...unordered];
 }
 
 /**
@@ -212,6 +237,7 @@ export const createLoungeStore = () =>
     nextCircleId: 1,
     categoryOrder: [],
     categoryEmojis: {},
+    agentOrder: {},
     hydrated: false,
 
     deriveCategories(projects: ProjectInfo[]) {
@@ -297,9 +323,52 @@ export const createLoungeStore = () =>
 
     moveAgent(agentId: string, targetCategoryId: string) {
       if (!get().hydrated) return;
-      set((state) => ({
-        agentCategoryOverrides: { ...state.agentCategoryOverrides, [agentId]: targetCategoryId },
-      }));
+      set((state) => {
+        // Remove from old category's agent order
+        const newAgentOrder = { ...state.agentOrder };
+        for (const [catId, order] of Object.entries(newAgentOrder)) {
+          if (order.includes(agentId)) {
+            newAgentOrder[catId] = order.filter((id) => id !== agentId);
+          }
+        }
+        // Append to new category's agent order
+        const targetOrder = newAgentOrder[targetCategoryId] ?? [];
+        newAgentOrder[targetCategoryId] = [...targetOrder, agentId];
+        return {
+          agentCategoryOverrides: { ...state.agentCategoryOverrides, [agentId]: targetCategoryId },
+          agentOrder: newAgentOrder,
+        };
+      });
+    },
+
+    placeAgent(agentId: string, targetCategoryId: string, beforeAgentId: string | null) {
+      if (!get().hydrated) return;
+      set((state) => {
+        const newAgentOrder = { ...state.agentOrder };
+        // Remove from all category orders
+        for (const [catId, order] of Object.entries(newAgentOrder)) {
+          if (order.includes(agentId)) {
+            newAgentOrder[catId] = order.filter((id) => id !== agentId);
+          }
+        }
+        // Insert into target category at position
+        const targetOrder = [...(newAgentOrder[targetCategoryId] ?? [])];
+        if (beforeAgentId) {
+          const idx = targetOrder.indexOf(beforeAgentId);
+          if (idx >= 0) {
+            targetOrder.splice(idx, 0, agentId);
+          } else {
+            targetOrder.push(agentId);
+          }
+        } else {
+          targetOrder.push(agentId);
+        }
+        newAgentOrder[targetCategoryId] = targetOrder;
+        return {
+          agentCategoryOverrides: { ...state.agentCategoryOverrides, [agentId]: targetCategoryId },
+          agentOrder: newAgentOrder,
+        };
+      });
     },
 
     addCircle(label: string): string {
@@ -343,6 +412,7 @@ export const createLoungeStore = () =>
         const newOrder = state.categoryOrder.filter((id) => id !== circleId);
         const { [circleId]: _emoji, ...newEmojis } = state.categoryEmojis;
         const { [circleId]: _label, ...newLabels } = state.renamedLabels;
+        const { [circleId]: _agentOrder, ...newAgentOrder } = state.agentOrder;
         const newCollapsed = new Set(state.collapsed);
         newCollapsed.delete(circleId);
         return {
@@ -352,6 +422,7 @@ export const createLoungeStore = () =>
           categoryOrder: newOrder,
           categoryEmojis: newEmojis,
           renamedLabels: newLabels,
+          agentOrder: newAgentOrder,
           collapsed: newCollapsed,
         };
       });
@@ -403,6 +474,7 @@ export const createLoungeStore = () =>
         nextCircleId: data.nextCircleId ?? 1,
         categoryOrder: data.categoryOrder ?? [],
         categoryEmojis: data.categoryEmojis ?? {},
+        agentOrder: data.agentOrder ?? {},
         collapsed: new Set(data.collapsed ?? []),
         hydrated: true,
       });

--- a/plugins/lounge/src/state.ts
+++ b/plugins/lounge/src/state.ts
@@ -64,6 +64,12 @@ export interface LoungeState {
   agentOrder: Record<string, string[]>;
   /** Whether persisted state has been loaded (blocks mutations until true). */
   hydrated: boolean;
+  /** Whether agent tag badges are visible. */
+  showTags: boolean;
+  /** Whether the sidebar is collapsed. */
+  sidebarCollapsed: boolean;
+  /** Sidebar width in pixels (persisted). */
+  sidebarWidth: number;
 
   // Actions
   deriveCategories(projects: ProjectInfo[]): void;
@@ -76,6 +82,9 @@ export interface LoungeState {
   deleteCircle(circleId: string): void;
   reorderCategory(fromId: string, toId: string): void;
   setCategoryEmoji(categoryId: string, emoji: string): void;
+  toggleShowTags(): void;
+  toggleSidebar(): void;
+  setSidebarWidth(width: number): void;
   /** Hydrate store from persisted data. */
   loadPersistedState(data: LoungePersistedState): void;
 }
@@ -90,6 +99,9 @@ export interface LoungePersistedState {
   categoryEmojis: Record<string, string>;
   agentOrder: Record<string, string[]>;
   collapsed: string[];
+  showTags: boolean;
+  sidebarCollapsed: boolean;
+  sidebarWidth: number;
 }
 
 /** Extract the persistable subset from the store. */
@@ -103,6 +115,9 @@ export function getPersistedState(state: LoungeState): LoungePersistedState {
     categoryEmojis: state.categoryEmojis,
     agentOrder: state.agentOrder,
     collapsed: Array.from(state.collapsed),
+    showTags: state.showTags,
+    sidebarCollapsed: state.sidebarCollapsed,
+    sidebarWidth: state.sidebarWidth,
   };
 }
 
@@ -239,6 +254,9 @@ export const createLoungeStore = () =>
     categoryEmojis: {},
     agentOrder: {},
     hydrated: false,
+    showTags: true,
+    sidebarCollapsed: false,
+    sidebarWidth: 256,
 
     deriveCategories(projects: ProjectInfo[]) {
       set((state) => {
@@ -472,6 +490,19 @@ export const createLoungeStore = () =>
       });
     },
 
+    toggleShowTags() {
+      set((state) => ({ showTags: !state.showTags }));
+    },
+
+    toggleSidebar() {
+      set((state) => ({ sidebarCollapsed: !state.sidebarCollapsed }));
+    },
+
+    setSidebarWidth(width: number) {
+      const clamped = Math.max(160, Math.min(480, width));
+      set({ sidebarWidth: clamped });
+    },
+
     loadPersistedState(data: LoungePersistedState) {
       set({
         renamedLabels: data.renamedLabels ?? {},
@@ -482,6 +513,9 @@ export const createLoungeStore = () =>
         categoryEmojis: data.categoryEmojis ?? {},
         agentOrder: data.agentOrder ?? {},
         collapsed: new Set(data.collapsed ?? []),
+        showTags: data.showTags ?? true,
+        sidebarCollapsed: data.sidebarCollapsed ?? false,
+        sidebarWidth: data.sidebarWidth ?? 256,
         hydrated: true,
       });
     },

--- a/plugins/lounge/src/tag-helpers.test.ts
+++ b/plugins/lounge/src/tag-helpers.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getOrchestratorColor,
+  getOrchestratorLabel,
+  formatModelLabel,
+  getModelColor,
+  getModelTagColor,
+  ORCHESTRATOR_COLORS,
+  DEFAULT_ORCH_COLOR,
+  FREE_AGENT_COLOR,
+} from './tag-helpers';
+
+describe('getOrchestratorColor', () => {
+  it('returns orange for claude-code', () => {
+    expect(getOrchestratorColor('claude-code')).toEqual(ORCHESTRATOR_COLORS['claude-code']);
+  });
+
+  it('returns blue for copilot-cli', () => {
+    expect(getOrchestratorColor('copilot-cli')).toEqual(ORCHESTRATOR_COLORS['copilot-cli']);
+  });
+
+  it('returns default grey for unknown orchestrator', () => {
+    expect(getOrchestratorColor('unknown-orch')).toEqual(DEFAULT_ORCH_COLOR);
+  });
+});
+
+describe('getOrchestratorLabel', () => {
+  it('uses shortName from orchestrator list when available', () => {
+    const orchestrators = [{ id: 'claude-code', displayName: 'Claude Code Agent', shortName: 'CC' }];
+    expect(getOrchestratorLabel('claude-code', orchestrators)).toBe('CC');
+  });
+
+  it('falls back to displayName when shortName is absent', () => {
+    const orchestrators = [{ id: 'claude-code', displayName: 'Claude Code Agent' }];
+    expect(getOrchestratorLabel('claude-code', orchestrators)).toBe('Claude Code Agent');
+  });
+
+  it('falls back to static map when not in orchestrator list', () => {
+    expect(getOrchestratorLabel('claude-code', [])).toBe('CC');
+    expect(getOrchestratorLabel('copilot-cli', [])).toBe('GHCP');
+    expect(getOrchestratorLabel('codex-cli', [])).toBe('Codex');
+  });
+
+  it('falls back to raw ID when not in static map', () => {
+    expect(getOrchestratorLabel('my-custom-orch', [])).toBe('my-custom-orch');
+  });
+
+  it('falls back to raw ID when orchestrator list is undefined', () => {
+    expect(getOrchestratorLabel('my-custom-orch')).toBe('my-custom-orch');
+  });
+
+  it('handles empty orchestrator list gracefully', () => {
+    expect(getOrchestratorLabel('claude-code', [])).toBe('CC');
+  });
+});
+
+describe('formatModelLabel', () => {
+  it('capitalizes model name', () => {
+    expect(formatModelLabel('sonnet')).toBe('Sonnet');
+  });
+
+  it('returns Default for undefined', () => {
+    expect(formatModelLabel(undefined)).toBe('Default');
+  });
+
+  it('returns Default for "default"', () => {
+    expect(formatModelLabel('default')).toBe('Default');
+  });
+
+  it('handles single character', () => {
+    expect(formatModelLabel('a')).toBe('A');
+  });
+});
+
+describe('getModelColor', () => {
+  it('returns consistent color for same model', () => {
+    const color1 = getModelColor('sonnet');
+    const color2 = getModelColor('sonnet');
+    expect(color1).toBe(color2); // same reference from cache
+  });
+
+  it('returns a color with bg and text properties', () => {
+    const color = getModelColor('opus');
+    expect(color).toHaveProperty('bg');
+    expect(color).toHaveProperty('text');
+    expect(color.bg).toMatch(/^rgba\(/);
+    expect(color.text).toMatch(/^#/);
+  });
+
+  it('different models may get different colors', () => {
+    const c1 = getModelColor('sonnet');
+    const c2 = getModelColor('opus');
+    // They could theoretically hash to the same bucket, but these specific strings don't
+    expect(c1 !== c2 || c1.bg !== c2.bg).toBe(true);
+  });
+});
+
+describe('getModelTagColor', () => {
+  it('returns default grey for undefined model', () => {
+    const color = getModelTagColor(undefined);
+    expect(color.text).toBe('#94a3b8');
+  });
+
+  it('returns default grey for "default" model', () => {
+    const color = getModelTagColor('default');
+    expect(color.text).toBe('#94a3b8');
+  });
+
+  it('returns hash-based color for custom model', () => {
+    const color = getModelTagColor('sonnet');
+    expect(color.text).not.toBe('#94a3b8');
+  });
+});
+
+describe('FREE_AGENT_COLOR', () => {
+  it('has red tones', () => {
+    expect(FREE_AGENT_COLOR.text).toBe('#f87171');
+    expect(FREE_AGENT_COLOR.bg).toContain('239,68,68');
+  });
+});

--- a/plugins/lounge/src/tag-helpers.ts
+++ b/plugins/lounge/src/tag-helpers.ts
@@ -1,0 +1,84 @@
+/**
+ * Orchestrator and model tag color/label helpers.
+ * Reimplements the host app's orchestrator-colors.ts logic inline
+ * so community plugins can render matching tag badges.
+ */
+
+// ── Orchestrator colors ────────────────────────────────────────────────
+
+export const ORCHESTRATOR_COLORS: Record<string, { bg: string; text: string }> = {
+  'claude-code': { bg: 'rgba(249,115,22,0.2)', text: '#fb923c' },
+  'copilot-cli': { bg: 'rgba(59,130,246,0.2)', text: '#60a5fa' },
+};
+export const DEFAULT_ORCH_COLOR = { bg: 'rgba(148,163,184,0.2)', text: '#94a3b8' };
+
+export function getOrchestratorColor(id: string): { bg: string; text: string } {
+  return ORCHESTRATOR_COLORS[id] || DEFAULT_ORCH_COLOR;
+}
+
+// ── Orchestrator labels ────────────────────────────────────────────────
+
+const ORCHESTRATOR_DISPLAY_NAMES: Record<string, string> = {
+  'claude-code': 'CC',
+  'copilot-cli': 'GHCP',
+  'codex-cli': 'Codex',
+};
+
+/**
+ * Resolve a short display label for an orchestrator ID (for badge use).
+ * Fallback chain: orchestrator shortName → static map → raw ID.
+ */
+export function getOrchestratorLabel(
+  orchId: string,
+  allOrchestrators?: Array<{ id: string; shortName?: string; displayName?: string }>,
+): string {
+  const info = allOrchestrators?.find((o) => o.id === orchId);
+  if (info) return info.shortName || info.displayName || orchId;
+  return ORCHESTRATOR_DISPLAY_NAMES[orchId] || orchId;
+}
+
+// ── Model colors ───────────────────────────────────────────────────────
+
+const MODEL_PALETTE = [
+  { bg: 'rgba(168,85,247,0.2)', text: '#c084fc' },
+  { bg: 'rgba(20,184,166,0.2)', text: '#2dd4bf' },
+  { bg: 'rgba(236,72,153,0.2)', text: '#f472b6' },
+  { bg: 'rgba(34,197,94,0.2)', text: '#4ade80' },
+  { bg: 'rgba(251,191,36,0.2)', text: '#fbbf24' },
+  { bg: 'rgba(99,102,241,0.2)', text: '#818cf8' },
+  { bg: 'rgba(14,165,233,0.2)', text: '#38bdf8' },
+];
+
+const DEFAULT_MODEL_COLOR = { bg: 'rgba(148,163,184,0.15)', text: '#94a3b8' };
+
+const modelColorCache = new Map<string, { bg: string; text: string }>();
+
+export function getModelColor(model: string): { bg: string; text: string } {
+  let color = modelColorCache.get(model);
+  if (!color) {
+    let hash = 0;
+    for (let i = 0; i < model.length; i++) hash = (hash * 31 + model.charCodeAt(i)) | 0;
+    color = MODEL_PALETTE[((hash % MODEL_PALETTE.length) + MODEL_PALETTE.length) % MODEL_PALETTE.length];
+    modelColorCache.set(model, color);
+  }
+  return color;
+}
+
+// ── Model labels ───────────────────────────────────────────────────────
+
+export function formatModelLabel(model: string | undefined): string {
+  if (!model || model === 'default') return 'Default';
+  return model.charAt(0).toUpperCase() + model.slice(1);
+}
+
+/** Free agent mode badge color */
+export const FREE_AGENT_COLOR = { bg: 'rgba(239,68,68,0.15)', text: '#f87171' };
+
+/**
+ * Get the color for a model tag badge.
+ * Returns the default (grey) for undefined / 'default', otherwise hash-based.
+ */
+export function getModelTagColor(model: string | undefined): { bg: string; text: string } {
+  if (!model || model === 'default') return DEFAULT_MODEL_COLOR;
+  return getModelColor(model);
+}

--- a/plugins/lounge/tsconfig.json
+++ b/plugins/lounge/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist",
+    "declaration": false,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/plugins/lounge/vitest.config.ts
+++ b/plugins/lounge/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+});


### PR DESCRIPTION
A Teams-style sidebar for browsing AI agents across all projects, organized into customizable circles (categories), with rich agent avatars and metadata tags.

## Features

### Core Browser
- Agent browser sidebar with project-derived categories
- Custom circles: create, rename, delete via unified modal dialog
- Emoji icons for circles with inline picker
- Drag-and-drop: move agents between circles, reorder agents within circles
- Context menus: Move To, Stop/Wake/Pop Out on agents; Rename/Delete on circles
- Persistent config via global storage with debounced auto-save
- Race-condition-safe hydration: circle assignments survive app restarts
- Active/total agent count in circle headers

### Agent Avatars & Status Ring
- Host `AgentAvatar` widget via `api.widgets.AgentAvatar` with animated status ring
- Green (running), gray (sleeping), amber (waking), red (error) ring colors
- Status text below tags: Thinking/Sleeping/Error with colored attention states
- Replaces old dot indicators

### Agent Tags
- Provider tag (GHCP, CC, Codex) via orchestrator `shortName`
- Model tag with hash-based 7-color palette
- Free agent mode badge (red)
- Toggle button in header, `showTags` persisted

### Collapsible Resizable Sidebar
- Drag-to-resize divider (160-480px range, matches host `ResizeDivider` pattern)
- Hover-only chevron on divider edge, double-click to toggle
- CSS transition animation for collapse/expand
- `sidebarCollapsed` + `sidebarWidth` persisted

## Technical

- API v0.8 | 139 tests passing across 4 files | typecheck clean
- zustand store with persisted agent ordering, categories, tags, and sidebar state
- `tag-helpers.ts` with full orchestrator color/label/model helpers (20 tests)
- Backward-compatible state hydration for all new persisted fields
- Plugin hot-reloads without app restart